### PR TITLE
NISP-1996: Handle MCI and Dead error scenarios

### DIFF
--- a/app/uk/gov/hmrc/statepension/controllers/ErrorResponses.scala
+++ b/app/uk/gov/hmrc/statepension/controllers/ErrorResponses.scala
@@ -24,6 +24,6 @@ object ErrorResponses {
   val CODE_DEAD = "EXCLUSION_DEAD"
 
   object ErrorNinoInvalid extends ErrorResponse(400, CODE_INVALID_NINO, "The provided NINO is not valid")
-  object ExclusionManualCorrespondence extends ErrorResponse(403, CODE_MANUAL_CORRESPONDENCE, "User cannot access the service, the customer needs to contact HMRC")
+  object ExclusionManualCorrespondence extends ErrorResponse(403, CODE_MANUAL_CORRESPONDENCE, "The customer cannot access the service, they should contact HMRC")
   object ExclusionDead extends ErrorResponse(403, CODE_DEAD, "The customer needs to contact the National Insurance helpline")
 }

--- a/app/uk/gov/hmrc/statepension/controllers/ErrorResponses.scala
+++ b/app/uk/gov/hmrc/statepension/controllers/ErrorResponses.scala
@@ -20,6 +20,10 @@ import uk.gov.hmrc.api.controllers.ErrorResponse
 
 object ErrorResponses {
   val CODE_INVALID_NINO = "ERROR_NINO_INVALID"
+  val CODE_MANUAL_CORRESPONDENCE = "EXCLUSION_MANUAL_CORRESPONDENCE"
+  val CODE_DEAD = "EXCLUSION_DEAD"
 
   object ErrorNinoInvalid extends ErrorResponse(400, CODE_INVALID_NINO, "The provided NINO is not valid")
+  object ExclusionManualCorrespondence extends ErrorResponse(403, CODE_MANUAL_CORRESPONDENCE, "User cannot access the service, the customer needs to contact HMRC")
+  object ExclusionDead extends ErrorResponse(403, CODE_DEAD, "The customer needs to contact the National Insurance helpline")
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -86,7 +86,7 @@ controllers {
     }
 
     uk.gov.hmrc.statepension.controllers.live.StatePensionController = {
-        needsAuth = true
+        needsAuth = false
         needsLogging = true
         needsAuditing = false
         authParams = {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -80,7 +80,7 @@ controllers {
     }
 
     uk.gov.hmrc.statepension.controllers.sandbox.StatePensionController = {
-        needsAuth = false
+        needsAuth = true
         needsLogging = true
         needsAuditing = false
     }

--- a/conf/resources/sandbox/EZ.json
+++ b/conf/resources/sandbox/EZ.json
@@ -1,0 +1,7 @@
+{
+  "exclusionReasons": [
+    "Dead"
+  ],
+  "pensionAge": 66,
+  "pensionDate": "2021-05-16"
+}

--- a/conf/resources/sandbox/PG.json
+++ b/conf/resources/sandbox/PG.json
@@ -1,0 +1,7 @@
+{
+  "exclusionReasons": [
+    "ManualCorrespondenceIndicator"
+  ],
+  "pensionAge": 66,
+  "pensionDate": "2021-05-16"
+}

--- a/public/api/documentation/1.0/State-Pension.xml
+++ b/public/api/documentation/1.0/State-Pension.xml
@@ -302,11 +302,6 @@
                     <cell>Current marital status required, unable to determine State Pension amounts</cell>
                 </row>
                 <row>
-                    <cell><code>Dead</code></cell>
-                    <cell>The customer has a Date of Death present on their record</cell>
-                    <cell>If this is incorrect the customer should call the National Insurance Helpline to have this amended</cell>
-                </row>
-                <row>
                     <cell><code>AmountDissonance</code></cell>
                     <cell>Contention between amounts on internal systems</cell>
                     <cell>There is contention between the pension amounts in the internal systems, therefore a reliable forecast cannot be provided</cell>
@@ -329,9 +324,39 @@
             </headings>
             <rows>
                 <row>
-                    <cell>TODO</cell>
-                    <cell><code>TODO</code></cell>
-                    <cell><code>TODO</code></cell>
+                    <cell>Invalid NINO requested</cell>
+                    <cell><code>400</code></cell>
+                    <cell><code>ERROR_NINO_INVALID</code></cell>
+                </row>
+                <row>
+                    <cell>Manual Correspondence exclusion, the customer cannot be served digitally and needs to contact HMRC</cell>
+                    <cell><code>403</code></cell>
+                    <cell><code>EXCLUSION_MANUAL_CORRESPONDENCE</code></cell>
+                </row>
+                <row>
+                    <cell>Death recorded, the customer needs to contact the National Insurance Helpline</cell>
+                    <cell><code>403</code></cell>
+                    <cell><code>EXCLUSION_DEAD</code></cell>
+                </row>
+                <row>
+                    <cell>Bad Request from Upstream, check if the customer is below State Pension age</cell>
+                    <cell><code>400</code></cell>
+                    <cell><code>BAD_REQUEST</code></cell>
+                </row>
+                <row>
+                    <cell>Internal Server Error</cell>
+                    <cell><code>500</code></cell>
+                    <cell><code>INTERNAL_SERVER_ERROR</code></cell>
+                </row>
+                <row>
+                    <cell>Unauthorized</cell>
+                    <cell><code>401</code></cell>
+                    <cell><code>UNAUTHORIZED</code></cell>
+                </row>
+                <row>
+                    <cell>Invalid Accept Headers</cell>
+                    <cell><code>406</code></cell>
+                    <cell><code>ACCEPT_HEADER_INVALID</code></cell>
                 </row>
             </rows>
         </table>
@@ -403,6 +428,14 @@
                 <row>
                     <cell><code>AP</code></cell>
                     <cell>A user who has already reached the full State Pension rate</cell>
+                </row>
+                <row>
+                    <cell><code>EZ</code></cell>
+                    <cell>A user who is dead</cell>
+                </row>
+                <row>
+                    <cell><code>PG</code></cell>
+                    <cell>A user who has manual correspondence only and cannot use the service</cell>
                 </row>
             </rows>
         </table>

--- a/test/uk/gov/hmrc/statepension/controllers/StatePensionControllerSpec.scala
+++ b/test/uk/gov/hmrc/statepension/controllers/StatePensionControllerSpec.scala
@@ -22,10 +22,10 @@ import play.api.test.FakeRequest
 import uk.gov.hmrc.domain.{Generator, Nino}
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 import uk.gov.hmrc.statepension.controllers.StatePensionController
-import uk.gov.hmrc.statepension.domain.{StatePension, StatePensionAmount, StatePensionAmounts, StatePensionExclusion}
+import uk.gov.hmrc.statepension.domain._
 import uk.gov.hmrc.statepension.services.StatePensionService
 import play.api.test.Helpers._
-import uk.gov.hmrc.play.http.{HeaderCarrier, BadRequestException}
+import uk.gov.hmrc.play.http.{BadRequestException, HeaderCarrier}
 
 import scala.concurrent.Future
 import scala.util.Random
@@ -101,6 +101,24 @@ class StatePensionControllerSpec extends UnitSpec with WithFakeApplication {
 
       status(response) shouldBe 400
       contentAsJson(response) shouldBe Json.parse("""{"code":"BAD_REQUEST","message":"Upstream Bad Request. Is this customer below State Pension Age?"}""")
+    }
+
+    "return 403 with an error message for an MCI exclusion" in {
+      val response = testStatePensionController(new StatePensionService {
+        override def getStatement(nino: Nino)(implicit hc: HeaderCarrier): Future[Either[StatePensionExclusion, StatePension]] = Left(StatePensionExclusion(List(Exclusion.ManualCorrespondenceIndicator), 0, new LocalDate(2050, 1, 1)))
+      }).get(nino)(emptyRequestWithHeader)
+
+      status(response) shouldBe 403
+      contentAsJson(response) shouldBe Json.parse("""{"code":"EXCLUSION_MANUAL_CORRESPONDENCE","message":"User cannot access the service, the customer needs to contact HMRC"}""")
+    }
+
+    "return 403 with an error message for a Dead exclusion" in {
+      val response = testStatePensionController(new StatePensionService {
+        override def getStatement(nino: Nino)(implicit hc: HeaderCarrier): Future[Either[StatePensionExclusion, StatePension]] = Left(StatePensionExclusion(List(Exclusion.Dead), 0, new LocalDate(2050, 1, 1)))
+      }).get(nino)(emptyRequestWithHeader)
+
+      status(response) shouldBe 403
+      contentAsJson(response) shouldBe Json.parse("""{"code":"EXCLUSION_DEAD","message":"The customer needs to contact the National Insurance helpline"}""")
     }
 
   }

--- a/test/uk/gov/hmrc/statepension/services/StatePensionServiceSpec.scala
+++ b/test/uk/gov/hmrc/statepension/services/StatePensionServiceSpec.scala
@@ -85,6 +85,32 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         ))
       }
     }
+
+    "EZ prefix should return Dead exclusion" in {
+      whenReady(SandboxStatePensionService.getStatement(generateNinoWithPrefix("EZ"))(HeaderCarrier())) { result =>
+        result shouldBe Left(StatePensionExclusion(
+          exclusionReasons = List(Exclusion.Dead),
+          pensionAge = 66,
+          pensionDate = new LocalDate(2021, 5, 16)
+        ))
+      }
+    }
+
+    "PG prefix should return MCI exclusion" in {
+      whenReady(SandboxStatePensionService.getStatement(generateNinoWithPrefix("PG"))(HeaderCarrier())) { result =>
+        result shouldBe Left(StatePensionExclusion(
+          exclusionReasons = List(Exclusion.ManualCorrespondenceIndicator),
+          pensionAge = 66,
+          pensionDate = new LocalDate(2021, 5, 16)
+        ))
+      }
+    }
+
+
+
+
+
+
     
   }
 }


### PR DESCRIPTION
* MCI and Dead have been turned into 403 with all relevant message
* They are `PG` and `EZ` in the sandbox respectively
* Added error scenarios to documentation