### PR TITLE
NISP-2131: Update Pattern Regex for to include /ni/

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -91,7 +91,7 @@ controllers {
         needsAuditing = false
         authParams = {
             account = "paye"
-            pattern = """\/(.{0})([^\/]+)\/?.*"""
+            pattern = """\/(.{0})ni\/([^\/]+)\/?.*"""
             privilegedAccess = "read:state-pension"
         }
     }


### PR DESCRIPTION
This change makes us capture the correct identifier for Auth.
Previously it was sending `/authorise/paye/ni` now it will send `/authorise/paye/{nino}`
This was not picked up on previously because privilegedAccess was overriding it.