### PR TITLE
Add Configuration for API Status

### DIFF
--- a/app/uk/gov/hmrc/statepension/config/AppContext.scala
+++ b/app/uk/gov/hmrc/statepension/config/AppContext.scala
@@ -25,6 +25,7 @@ trait AppContext {
   def appUrl: String
   def apiGatewayContext: String
   def access: Option[Configuration]
+  def status: Option[String]
 }
 
 object AppContext extends AppContext with ServicesConfig {
@@ -33,4 +34,5 @@ object AppContext extends AppContext with ServicesConfig {
   lazy val apiGatewayContext = current.configuration.getString("api.gateway.context")
     .getOrElse(throw new RuntimeException("api.gateway.context is not configured"))
   lazy val access = current.configuration.getConfig("api.access")
+  lazy val status = current.configuration.getString("api.status")
 }

--- a/app/uk/gov/hmrc/statepension/controllers/DocumentationController.scala
+++ b/app/uk/gov/hmrc/statepension/controllers/DocumentationController.scala
@@ -26,13 +26,15 @@ trait DocumentationController extends uk.gov.hmrc.api.controllers.DocumentationC
   val appContext: AppContext
 
   override def definition(): Action[AnyContent] = Action {
-    Ok(txt.definition(buildAccess())).withHeaders("Content-Type" -> "application/json")
+    Ok(txt.definition(buildAccess(), buildStatus())).withHeaders("Content-Type" -> "application/json")
   }
 
   private def buildAccess(): APIAccess = {
     val access = APIAccessConfig(appContext.access)
     APIAccess(access.accessType, access.whiteListedApplicationIds)
   }
+
+  private def buildStatus(): String = appContext.status.getOrElse("PROTOTYPED")
 }
 
 object DocumentationController extends DocumentationController {

--- a/app/uk/gov/hmrc/statepension/views/definition.scala.txt
+++ b/app/uk/gov/hmrc/statepension/views/definition.scala.txt
@@ -2,7 +2,7 @@
 @import play.api.libs.json.Json
 
 
-@(access: APIAccess)
+@(access: APIAccess, status: String)
 {
   "scopes": [
     {
@@ -18,7 +18,7 @@
     "versions": [
       {
         "version": "1.0",
-        "status": "PUBLISHED",
+        "status": "@status",
         "access" : @Json.toJson(access),
         "endpoints": [
           {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -153,9 +153,12 @@ auditing {
 }
 
 # API Access Configuration
-api.access {
-    type = PUBLIC
-    whitelist.applicationIds = []
+api {
+    access {
+        type = PUBLIC
+        whitelist.applicationIds = []
+    }
+    status = PUBLISHED
 }
 
 microservice {

--- a/test/uk/gov/hmrc/statepension/controllers/DocumentationControllerSpec.scala
+++ b/test/uk/gov/hmrc/statepension/controllers/DocumentationControllerSpec.scala
@@ -37,49 +37,55 @@ class DocumentationControllerSpec extends UnitSpec with WithFakeApplication {
     status(result.get) shouldNot be(NOT_FOUND)
   }
 
+  def getDefinitionResultFromConfig(apiConfig: Option[Configuration] = None, apiStatus: Option[String] = None): Result = {
+
+    new DocumentationController {
+      override val appContext: AppContext = new AppContext {
+        override def appName: String = ""
+
+        override def apiGatewayContext: String = ""
+
+        override def appUrl: String = ""
+
+        override def access: Option[Configuration] = apiConfig
+
+        override def status: Option[String] = apiStatus
+      }
+    }.definition()(FakeRequest())
+
+  }
+
   "/definition access" should {
 
-    def getDefinitionResultFromConfig(apiConfig: Option[Configuration]): Result = {
 
-      new DocumentationController {
-        override val appContext: AppContext = new AppContext {
-          override def appName: String = ""
-          override def apiGatewayContext: String = ""
-          override def appUrl: String = ""
-
-          override def access: Option[Configuration] = apiConfig
-        }
-      }.definition()(FakeRequest())
-
-    }
 
     "return PRIVATE and no Whitelist IDs if there is no application config" in {
 
       val result = getDefinitionResultFromConfig(apiConfig = None)
       status(result) shouldBe OK
-      (contentAsJson(result) \ "api" \ "versions")(0) \ "access" \ "type" shouldBe JsString("PRIVATE")
-      (contentAsJson(result) \ "api" \ "versions")(0) \ "access" \ "whitelistedApplicationIds" shouldBe JsArray()
+      (contentAsJson(result) \ "api" \ "versions") (0) \ "access" \ "type" shouldBe JsString("PRIVATE")
+      (contentAsJson(result) \ "api" \ "versions") (0) \ "access" \ "whitelistedApplicationIds" shouldBe JsArray()
     }
 
     "return PRIVATE if the application config says PRIVATE" in {
 
       val result = getDefinitionResultFromConfig(apiConfig = Some(Configuration.from(Map("type" -> "PRIVATE"))))
       status(result) shouldBe OK
-      (contentAsJson(result) \ "api" \ "versions")(0) \ "access" \ "type" shouldBe JsString("PRIVATE")
+      (contentAsJson(result) \ "api" \ "versions") (0) \ "access" \ "type" shouldBe JsString("PRIVATE")
     }
 
     "return PUBLIC if the application config says PUBLIC" in {
 
       val result = getDefinitionResultFromConfig(apiConfig = Some(Configuration.from(Map("type" -> "PUBLIC"))))
       status(result) shouldBe OK
-      (contentAsJson(result) \ "api" \ "versions")(0) \ "access" \ "type" shouldBe JsString("PUBLIC")
+      (contentAsJson(result) \ "api" \ "versions") (0) \ "access" \ "type" shouldBe JsString("PUBLIC")
     }
 
     "return No Whitelist IDs if the application config has an entry for whiteListIds but no Ids" in {
 
       val result = getDefinitionResultFromConfig(apiConfig = Some(Configuration.from(Map("type" -> "PRIVATE", "whitelist.applicationIds" -> Seq()))))
       status(result) shouldBe OK
-      (contentAsJson(result) \ "api" \ "versions")(0) \ "access" \ "whitelistedApplicationIds" shouldBe JsArray()
+      (contentAsJson(result) \ "api" \ "versions") (0) \ "access" \ "whitelistedApplicationIds" shouldBe JsArray()
 
     }
 
@@ -87,8 +93,36 @@ class DocumentationControllerSpec extends UnitSpec with WithFakeApplication {
 
       val result = getDefinitionResultFromConfig(apiConfig = Some(Configuration.from(Map("type" -> "PRIVATE", "whitelist.applicationIds" -> Seq("A", "B", "C")))))
       status(result) shouldBe OK
-      (contentAsJson(result) \ "api" \ "versions")(0) \ "access" \ "whitelistedApplicationIds" shouldBe JsArray(Seq(JsString("A"), JsString("B"), JsString("C")))
+      (contentAsJson(result) \ "api" \ "versions") (0) \ "access" \ "whitelistedApplicationIds" shouldBe JsArray(Seq(JsString("A"), JsString("B"), JsString("C")))
 
     }
+  }
+
+  "/definition status" should {
+
+
+
+    "return PROTOTYPED if there is no application config" in {
+
+      val result = getDefinitionResultFromConfig(apiStatus = None)
+      status(result) shouldBe OK
+      (contentAsJson(result) \ "api" \ "versions") (0) \ "status" shouldBe JsString("PROTOTYPED")
+    }
+
+    "return PROTOTYPED if the application config says PROTOTYPED" in {
+
+      val result = getDefinitionResultFromConfig(apiStatus = Some("PROTOTYPED"))
+      status(result) shouldBe OK
+      (contentAsJson(result) \ "api" \ "versions") (0) \ "status" shouldBe JsString("PROTOTYPED")
+    }
+
+    "return PUBLISHED if the application config says PUBLISHED" in {
+
+      val result = getDefinitionResultFromConfig(apiStatus = Some("PUBLISHED"))
+      status(result) shouldBe OK
+      (contentAsJson(result) \ "api" \ "versions") (0) \ "status" shouldBe JsString("PUBLISHED")
+
+    }
+
   }
 }


### PR DESCRIPTION
This allows the status to be changed via the configuration rather than having to release the whole codebase when we want to switch. This also allows it to have a different status per environments.

🎉 