### PR TITLE
Fix whitelistIds entry showing when not PRIVATE

### DIFF
--- a/app/uk/gov/hmrc/statepension/config/APIAccessConfig.scala
+++ b/app/uk/gov/hmrc/statepension/config/APIAccessConfig.scala
@@ -29,10 +29,13 @@ case class APIAccessConfig(value: Option[Configuration]) {
     }
   }
 
-  def whiteListedApplicationIds: Seq[String] = {
+  def whiteListedApplicationIds: Option[Seq[String]] = {
+    if(accessType == PRIVATE)
     value match {
-      case Some(config) => config.getStringSeq("whitelist.applicationIds").getOrElse(Seq())
-      case None => Seq()
+      case Some(config) => Some(config.getStringSeq("whitelist.applicationIds").getOrElse(Seq()))
+      case None => Some(Seq())
+    } else {
+      None
     }
   }
 

--- a/app/uk/gov/hmrc/statepension/config/APIAccessConfig.scala
+++ b/app/uk/gov/hmrc/statepension/config/APIAccessConfig.scala
@@ -30,10 +30,11 @@ case class APIAccessConfig(value: Option[Configuration]) {
   }
 
   def whiteListedApplicationIds: Option[Seq[String]] = {
-    if(accessType == PRIVATE)
-    value match {
-      case Some(config) => Some(config.getStringSeq("whitelist.applicationIds").getOrElse(Seq()))
-      case None => Some(Seq())
+    if(accessType == PRIVATE) {
+      value match {
+        case Some(config) => Some(config.getStringSeq("whitelist.applicationIds").getOrElse(Seq()))
+        case None => Some(Seq())
+      }
     } else {
       None
     }

--- a/app/uk/gov/hmrc/statepension/domain/APIAccess.scala
+++ b/app/uk/gov/hmrc/statepension/domain/APIAccess.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.statepension.domain
 
 import play.api.libs.json.Json
 
-case class APIAccess(`type`: String, whitelistedApplicationIds: Seq[String])
+case class APIAccess(`type`: String, whitelistedApplicationIds: Option[Seq[String]])
 
 object APIAccess {
   implicit val formats = Json.format[APIAccess]

--- a/test/uk/gov/hmrc/statepension/controllers/DocumentationControllerSpec.scala
+++ b/test/uk/gov/hmrc/statepension/controllers/DocumentationControllerSpec.scala
@@ -96,6 +96,14 @@ class DocumentationControllerSpec extends UnitSpec with WithFakeApplication {
       (contentAsJson(result) \ "api" \ "versions") (0) \ "access" \ "whitelistedApplicationIds" shouldBe JsArray(Seq(JsString("A"), JsString("B"), JsString("C")))
 
     }
+
+    "return no whitelistApplicationIds entry if it is not PRIVATE" in {
+
+      val result = getDefinitionResultFromConfig(apiConfig = Some(Configuration.from(Map("type" -> "PUBLIC", "whitelist.applicationIds" -> Seq()))))
+      status(result) shouldBe OK
+      (contentAsJson(result) \ "api" \ "versions") (0) \ "access" \ "whitelistedApplicationIds" shouldBe a [JsUndefined]
+
+    }
   }
 
   "/definition status" should {


### PR DESCRIPTION
This is required to integrate with the Platform. 
It doesn't like:
```json
"access" : {"type":"PUBLIC", "whitelistApplicationIds": []}
```
so now it displays:
```json
"access" : {"type":"PUBLIC" }
```