### PR TITLE
NISP-2298: Adding Dead & Post State Pension Age & MWRRE & Overseas  Exclusions

### DIFF
--- a/app/uk/gov/hmrc/statepension/domain/nps/Country.scala
+++ b/app/uk/gov/hmrc/statepension/domain/nps/Country.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.statepension.domain.nps
+
+
+object Country {
+
+  final val GREAT_BRITAIN = 1
+  final val ISLE_OF_MAN = 7
+  final val ENGLAND = 114
+  final val SCOTLAND = 115
+  final val WALES = 116
+  final val NORTHERN_IRELAND = 8
+  final val NOT_SPECIFIED = 0
+
+  def isAbroad(countryCode: Int): Boolean = {
+    countryCode match {
+      case NOT_SPECIFIED => false
+      case GREAT_BRITAIN => false
+      case ENGLAND => false
+      case SCOTLAND => false
+      case WALES => false
+      case NORTHERN_IRELAND => false
+      case ISLE_OF_MAN => false
+      case _ => true
+    }
+  }
+
+}

--- a/app/uk/gov/hmrc/statepension/domain/nps/NpsSummary.scala
+++ b/app/uk/gov/hmrc/statepension/domain/nps/NpsSummary.scala
@@ -30,6 +30,7 @@ case class NpsSummary(
                        pensionSharingOrderSERPS: Boolean,
                        dateOfBirth: LocalDate,
                        dateOfDeath: Option[LocalDate] = None,
+                       reducedRateElection: Boolean = false,
                        amounts: NpsStatePensionAmounts
                      ) {
   val finalRelevantYear: String = s"$finalRelevantStartYear-${(finalRelevantStartYear + 1).toString.takeRight(2)}"
@@ -50,6 +51,7 @@ object NpsSummary {
       readBooleanFromInt(JsPath \ "pension_share_order_serps") and
       (JsPath \ "date_of_birth").read[LocalDate] and
       (JsPath \ "date_of_death").readNullable[LocalDate] and
+      readBooleanFromInt(JsPath \ "rre_to_consider") and
       (JsPath \ "npsSpnam").read[NpsStatePensionAmounts]
     ) (NpsSummary.apply _)
 

--- a/app/uk/gov/hmrc/statepension/domain/nps/NpsSummary.scala
+++ b/app/uk/gov/hmrc/statepension/domain/nps/NpsSummary.scala
@@ -29,6 +29,7 @@ case class NpsSummary(
                        finalRelevantStartYear: Int,
                        pensionSharingOrderSERPS: Boolean,
                        dateOfBirth: LocalDate,
+                       dateOfDeath: Option[LocalDate] = None,
                        amounts: NpsStatePensionAmounts
                      ) {
   val finalRelevantYear: String = s"$finalRelevantStartYear-${(finalRelevantStartYear + 1).toString.takeRight(2)}"
@@ -48,6 +49,7 @@ object NpsSummary {
       (JsPath \ "final_relevant_year").read[Int] and
       readBooleanFromInt(JsPath \ "pension_share_order_serps") and
       (JsPath \ "date_of_birth").read[LocalDate] and
+      (JsPath \ "date_of_death").readNullable[LocalDate] and
       (JsPath \ "npsSpnam").read[NpsStatePensionAmounts]
     ) (NpsSummary.apply _)
 
@@ -58,8 +60,8 @@ case class NpsStatePensionAmounts(
                                    startingAmount2016: BigDecimal = 0,
                                    protectedPayment2016: BigDecimal = 0,
                                    additionalPensionAccruedLastTaxYear: BigDecimal = 0,
-                                   amountA2016: NpsAmountA2016,
-                                   amountB2016: NpsAmountB2016
+                                   amountA2016: NpsAmountA2016 = NpsAmountA2016(),
+                                   amountB2016: NpsAmountB2016 = NpsAmountB2016()
                                  )
 
 object NpsStatePensionAmounts {

--- a/app/uk/gov/hmrc/statepension/domain/nps/NpsSummary.scala
+++ b/app/uk/gov/hmrc/statepension/domain/nps/NpsSummary.scala
@@ -31,7 +31,8 @@ case class NpsSummary(
                        dateOfBirth: LocalDate,
                        dateOfDeath: Option[LocalDate] = None,
                        reducedRateElection: Boolean = false,
-                       amounts: NpsStatePensionAmounts
+                       countryCode: Int = 0,
+                       amounts: NpsStatePensionAmounts = NpsStatePensionAmounts()
                      ) {
   val finalRelevantYear: String = s"$finalRelevantStartYear-${(finalRelevantStartYear + 1).toString.takeRight(2)}"
   val statePensionAge: Int = new Period(dateOfBirth, statePensionAgeDate).getYears
@@ -52,6 +53,7 @@ object NpsSummary {
       (JsPath \ "date_of_birth").read[LocalDate] and
       (JsPath \ "date_of_death").readNullable[LocalDate] and
       readBooleanFromInt(JsPath \ "rre_to_consider") and
+      (JsPath \ "country_code").read[Int] and
       (JsPath \ "npsSpnam").read[NpsStatePensionAmounts]
     ) (NpsSummary.apply _)
 

--- a/app/uk/gov/hmrc/statepension/services/ExclusionService.scala
+++ b/app/uk/gov/hmrc/statepension/services/ExclusionService.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.statepension.services
+
+import org.joda.time.LocalDate
+import uk.gov.hmrc.statepension.domain.Exclusion
+import uk.gov.hmrc.statepension.domain.Exclusion.Exclusion
+
+class ExclusionService(dateOfDeath: Option[LocalDate], pensionDate: LocalDate, now: LocalDate) {
+
+  lazy val getExclusions: List[Exclusion] = checkDead(checkPostStatePensionAge(Nil))
+
+  val checkDead: (List[Exclusion]) => List[Exclusion] = (exclusionList: List[Exclusion]) =>
+    dateOfDeath.fold(exclusionList)(_ => Exclusion.Dead :: exclusionList)
+
+  val checkPostStatePensionAge: (List[Exclusion]) => List[Exclusion] = (exclusionList: List[Exclusion]) =>
+    if (!now.isBefore(pensionDate.minusDays(1))) {
+      Exclusion.PostStatePensionAge :: exclusionList
+    } else {
+      exclusionList
+    }
+
+}

--- a/app/uk/gov/hmrc/statepension/services/ExclusionService.scala
+++ b/app/uk/gov/hmrc/statepension/services/ExclusionService.scala
@@ -19,10 +19,11 @@ package uk.gov.hmrc.statepension.services
 import org.joda.time.LocalDate
 import uk.gov.hmrc.statepension.domain.Exclusion
 import uk.gov.hmrc.statepension.domain.Exclusion.Exclusion
+import uk.gov.hmrc.statepension.util.FunctionHelper
 
-class ExclusionService(dateOfDeath: Option[LocalDate], pensionDate: LocalDate, now: LocalDate) {
+class ExclusionService(dateOfDeath: Option[LocalDate], pensionDate: LocalDate, now: LocalDate, reducedRateElection: Boolean) {
 
-  lazy val getExclusions: List[Exclusion] = checkDead(checkPostStatePensionAge(Nil))
+  lazy val getExclusions: List[Exclusion] = exclusions(List())
 
   val checkDead: (List[Exclusion]) => List[Exclusion] = (exclusionList: List[Exclusion]) =>
     dateOfDeath.fold(exclusionList)(_ => Exclusion.Dead :: exclusionList)
@@ -34,4 +35,8 @@ class ExclusionService(dateOfDeath: Option[LocalDate], pensionDate: LocalDate, n
       exclusionList
     }
 
+  val checkMarriedWomensReducedRateElection: (List[Exclusion]) => List[Exclusion] = (exclusionList: List[Exclusion]) =>
+    if (reducedRateElection) Exclusion.MarriedWomenReducedRateElection :: exclusionList else exclusionList
+
+  private val exclusions = FunctionHelper.composeAll(List(checkDead, checkPostStatePensionAge, checkMarriedWomensReducedRateElection))
 }

--- a/app/uk/gov/hmrc/statepension/services/StatePensionService.scala
+++ b/app/uk/gov/hmrc/statepension/services/StatePensionService.scala
@@ -57,7 +57,8 @@ trait NpsConnection extends StatePensionService {
       val exclusions: List[Exclusion] = new ExclusionService(
         dateOfDeath = summary.dateOfDeath,
         pensionDate = summary.statePensionAgeDate,
-        now
+        now,
+        reducedRateElection = summary.reducedRateElection
       ).getExclusions
 
       if (exclusions.nonEmpty) {

--- a/app/uk/gov/hmrc/statepension/services/StatePensionService.scala
+++ b/app/uk/gov/hmrc/statepension/services/StatePensionService.scala
@@ -28,6 +28,7 @@ import uk.gov.hmrc.statepension.domain._
 import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext._
 import play.api.Play.current
 import uk.gov.hmrc.statepension.domain.Exclusion.Exclusion
+import uk.gov.hmrc.statepension.domain.nps.Country
 import uk.gov.hmrc.statepension.util.EitherReads._
 import uk.gov.hmrc.time.TaxYearResolver
 
@@ -58,7 +59,9 @@ trait NpsConnection extends StatePensionService {
         dateOfDeath = summary.dateOfDeath,
         pensionDate = summary.statePensionAgeDate,
         now,
-        reducedRateElection = summary.reducedRateElection
+        reducedRateElection = summary.reducedRateElection,
+        isAbroad = Country.isAbroad(summary.countryCode),
+        sex = summary.sex
       ).getExclusions
 
       if (exclusions.nonEmpty) {

--- a/app/uk/gov/hmrc/statepension/util/FunctionHelper.scala
+++ b/app/uk/gov/hmrc/statepension/util/FunctionHelper.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.statepension.util
+
+object FunctionHelper {
+  def composeAll[A](functionList: Seq[A => A]): A => A = functionList.foldLeft(identity[A] _)(_ compose _)
+}

--- a/test/uk/gov/hmrc/statepension/domain/nps/CountrySpec.scala
+++ b/test/uk/gov/hmrc/statepension/domain/nps/CountrySpec.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.statepension.domain.nps
+
+import uk.gov.hmrc.play.test.UnitSpec
+
+class CountrySpec extends UnitSpec{
+
+  "Not Specified should be 0" in {
+    Country.NOT_SPECIFIED shouldBe 0
+  }
+
+  "Great Britain should be 1" in {
+    Country.GREAT_BRITAIN shouldBe 1
+  }
+
+  "Northern Ireland should be 8" in {
+    Country.NORTHERN_IRELAND shouldBe 8
+  }
+
+  "England should be 114" in {
+    Country.ENGLAND shouldBe 114
+  }
+
+  "Scotland should be 115" in {
+    Country.SCOTLAND shouldBe 115
+  }
+
+  "Wales should be 116" in {
+    Country.WALES shouldBe 116
+  }
+
+  "Isle of Man should be 7" in {
+    Country.ISLE_OF_MAN shouldBe 7
+  }
+
+  "isAbroad" should {
+    "should return true if the Country is not in the UK" in {
+      Country.isAbroad(222) shouldBe true
+    }
+
+    "should return false if the Country is GREAT BRITAIN" in {
+      Country.isAbroad(Country.GREAT_BRITAIN) shouldBe false
+    }
+
+    "should return false if the Country is ISLE OF MAN" in {
+      Country.isAbroad(Country.ISLE_OF_MAN) shouldBe false
+    }
+
+    "should return false if the Country is NORTHERN IRELAND" in {
+      Country.isAbroad(Country.NORTHERN_IRELAND) shouldBe false
+    }
+
+    "should return false if the Country is ENGLAND" in {
+      Country.isAbroad(Country.ENGLAND) shouldBe false
+    }
+
+    "should return false if the Country is SCOTLAND" in {
+      Country.isAbroad(Country.SCOTLAND) shouldBe false
+    }
+
+    "should return false if the Country is WALES" in {
+      Country.isAbroad(Country.WALES) shouldBe false
+    }
+
+    "should return false if the Country is NOT SPECIFIED OR NOT USED" in {
+      Country.isAbroad(Country.NOT_SPECIFIED) shouldBe false
+    }
+
+  }
+}

--- a/test/uk/gov/hmrc/statepension/domain/nps/NpsSummarySpec.scala
+++ b/test/uk/gov/hmrc/statepension/domain/nps/NpsSummarySpec.scala
@@ -252,6 +252,12 @@ class NpsSummarySpec extends UnitSpec {
       }
     }
 
+    "parse the country code correctly" when {
+      "it exists as 1" in {
+        summaryJson.as[NpsSummary].countryCode shouldBe 1
+      }
+    }
+
     "parse the amounts correctly" in {
 
       summaryJson.as[NpsSummary].amounts shouldBe NpsStatePensionAmounts(
@@ -527,16 +533,13 @@ class NpsSummarySpec extends UnitSpec {
   "finalRelevantYear" when {
 
     def summaryWithFinalRelevantStartYear(finalRelevantStartYear: Int) = NpsSummary(
-      new LocalDate(2016, 4, 5),
-      "F",
-      20,
-      new LocalDate(2020, 6, 9),
-      finalRelevantStartYear,
-      false,
-      new LocalDate(1954, 3, 9),
-      None,
-      false,
-      NpsStatePensionAmounts(amountA2016 = NpsAmountA2016(), amountB2016 = NpsAmountB2016())
+      earningsIncludedUpTo = new LocalDate(2016, 4, 5),
+      sex = "F",
+      qualifyingYears = 20,
+      statePensionAgeDate = new LocalDate(2020, 6, 9),
+      finalRelevantStartYear = finalRelevantStartYear,
+      pensionSharingOrderSERPS = false,
+      dateOfBirth = new LocalDate(1960, 4, 5)
     )
 
 
@@ -568,16 +571,13 @@ class NpsSummarySpec extends UnitSpec {
   "statePensionAge" when {
 
     def summaryWithDOBandSPA(dateOfBirth: LocalDate, statePensionAgeDate: LocalDate) = NpsSummary(
-      new LocalDate(2016, 4, 5),
-      "F",
-      20,
-      statePensionAgeDate,
-      2020,
-      false,
-      dateOfBirth,
-      None,
-      false,
-      NpsStatePensionAmounts(amountA2016 = NpsAmountA2016(), amountB2016 = NpsAmountB2016())
+      earningsIncludedUpTo = new LocalDate(2016, 4, 5),
+      sex = "F",
+      qualifyingYears = 20,
+      statePensionAgeDate = statePensionAgeDate,
+      finalRelevantStartYear = 2020,
+      pensionSharingOrderSERPS = false,
+      dateOfBirth
     )
 
     "when the date of birth is 1950-1-1 and the state pension age date is 2017-1-1" should {

--- a/test/uk/gov/hmrc/statepension/domain/nps/NpsSummarySpec.scala
+++ b/test/uk/gov/hmrc/statepension/domain/nps/NpsSummarySpec.scala
@@ -116,6 +116,75 @@ class NpsSummarySpec extends UnitSpec {
       }
     }
 
+    "parse date of death correctly" when {
+
+      "it is null" in {
+        summaryJson.as[NpsSummary].dateOfDeath shouldBe None
+      }
+
+      "it exists as 2001-9-11" in {
+        Json.parse(
+          """
+            |{
+            |  "contracted_out_flag": 0,
+            |  "sensitive_flag": 0,
+            |  "spa_date": "2019-09-06",
+            |  "final_relevant_year": 2018,
+            |  "account_not_maintained_flag": null,
+            |  "npsPenfor": {
+            |    "forecast_amount": 160.19,
+            |    "nsp_max": 155.65,
+            |    "qualifying_years_at_spa": 40,
+            |    "forecast_amount_2016": 160.19
+            |  },
+            |  "pension_share_order_coeg": 0,
+            |  "date_of_death": "2000-09-13",
+            |  "sex": "M",
+            |  "npsSpnam": {
+            |    "nsp_entitlement": 161.18,
+            |    "ap_amount": 2.36,
+            |    "npsAmnbpr16": {
+            |      "main_component": 155.65,
+            |      "rebate_derived_amount": 0.0
+            |    },
+            |    "npsAmnapr16": {
+            |      "ltb_post97_ap_cash_value": 6.03,
+            |      "ltb_cat_a_cash_value": 119.3,
+            |      "ltb_post88_cod_cash_value": null,
+            |      "ltb_pre97_ap_cash_value": 17.79,
+            |      "ltb_pre88_cod_cash_value": null,
+            |      "grb_cash": 2.66,
+            |      "ltb_pst88_gmp_cash_value": null,
+            |      "pre88_gmp": null,
+            |      "ltb_post02_ap_cash_value": 15.4
+            |    },
+            |    "protected_payment_2016": 5.53,
+            |    "starting_amount": 161.18
+            |  },
+            |  "npsErrlist": {
+            |    "count": 0,
+            |    "mgt_check": 0,
+            |    "commit_status": 2,
+            |    "npsErritem": [],
+            |    "bfm_return_code": 0,
+            |    "data_not_found": 0
+            |  },
+            |  "date_of_birth": "1954-03-09",
+            |  "nsp_qualifying_years": 36,
+            |  "country_code": 1,
+            |  "nsp_requisite_years": 35,
+            |  "minimum_qualifying_period": 1,
+            |  "address_postcode": "WS9 8LL",
+            |  "rre_to_consider": 0,
+            |  "pension_share_order_serps": 1,
+            |  "nino": "QQ123456A",
+            |  "earnings_included_upto": "2015-04-05"
+            |}
+          """.stripMargin).as[NpsSummary].dateOfDeath shouldBe Some(new LocalDate(2000, 9, 13))
+      }
+
+    }
+
     "parse the amounts correctly" in {
 
       summaryJson.as[NpsSummary].amounts shouldBe NpsStatePensionAmounts(
@@ -397,6 +466,7 @@ class NpsSummarySpec extends UnitSpec {
       finalRelevantStartYear,
       false,
       new LocalDate(1954, 3, 9),
+      None,
       NpsStatePensionAmounts(amountA2016 = NpsAmountA2016(), amountB2016 = NpsAmountB2016())
     )
 
@@ -436,6 +506,7 @@ class NpsSummarySpec extends UnitSpec {
       2020,
       false,
       dateOfBirth,
+      None,
       NpsStatePensionAmounts(amountA2016 = NpsAmountA2016(), amountB2016 = NpsAmountB2016())
     )
 

--- a/test/uk/gov/hmrc/statepension/domain/nps/NpsSummarySpec.scala
+++ b/test/uk/gov/hmrc/statepension/domain/nps/NpsSummarySpec.scala
@@ -351,7 +351,7 @@ class NpsSummarySpec extends UnitSpec {
         }
 
         "parse post 88 GMP  correctly" when {
-          "it exists as 27.27" in {
+          "it exists as 26.26" in {
             amountJson.as[NpsStatePensionAmounts].amountA2016.post88GMP shouldBe 26.26
           }
 
@@ -403,7 +403,7 @@ class NpsSummarySpec extends UnitSpec {
         }
 
         "parse rebate derived amount correctly" when {
-          "it exists as 23.23" in {
+          "it exists as 13.13" in {
             amountJson.as[NpsStatePensionAmounts].amountB2016.rebateDerivedAmount shouldBe 13.13
           }
 

--- a/test/uk/gov/hmrc/statepension/domain/nps/NpsSummarySpec.scala
+++ b/test/uk/gov/hmrc/statepension/domain/nps/NpsSummarySpec.scala
@@ -185,6 +185,73 @@ class NpsSummarySpec extends UnitSpec {
 
     }
 
+
+    "parse reduced rate election correctly" when {
+      "it is 0 and therefore false" in {
+        summaryJson.as[NpsSummary].reducedRateElection shouldBe false
+      }
+      "it is higher and therefore true" in {
+        Json.parse(
+          """
+            |{
+            |  "contracted_out_flag": 0,
+            |  "sensitive_flag": 0,
+            |  "spa_date": "2019-09-06",
+            |  "final_relevant_year": 2018,
+            |  "account_not_maintained_flag": null,
+            |  "npsPenfor": {
+            |    "forecast_amount": 160.19,
+            |    "nsp_max": 155.65,
+            |    "qualifying_years_at_spa": 40,
+            |    "forecast_amount_2016": 160.19
+            |  },
+            |  "pension_share_order_coeg": 0,
+            |  "date_of_death": null,
+            |  "sex": "M",
+            |  "npsSpnam": {
+            |    "nsp_entitlement": 161.18,
+            |    "ap_amount": 2.36,
+            |    "npsAmnbpr16": {
+            |      "main_component": 155.65,
+            |      "rebate_derived_amount": 0.0
+            |    },
+            |    "npsAmnapr16": {
+            |      "ltb_post97_ap_cash_value": 6.03,
+            |      "ltb_cat_a_cash_value": 119.3,
+            |      "ltb_post88_cod_cash_value": null,
+            |      "ltb_pre97_ap_cash_value": 17.79,
+            |      "ltb_pre88_cod_cash_value": null,
+            |      "grb_cash": 2.66,
+            |      "ltb_pst88_gmp_cash_value": null,
+            |      "pre88_gmp": null,
+            |      "ltb_post02_ap_cash_value": 15.4
+            |    },
+            |    "protected_payment_2016": 5.53,
+            |    "starting_amount": 161.18
+            |  },
+            |  "npsErrlist": {
+            |    "count": 0,
+            |    "mgt_check": 0,
+            |    "commit_status": 2,
+            |    "npsErritem": [],
+            |    "bfm_return_code": 0,
+            |    "data_not_found": 0
+            |  },
+            |  "date_of_birth": "1954-03-09",
+            |  "nsp_qualifying_years": 36,
+            |  "country_code": 1,
+            |  "nsp_requisite_years": 35,
+            |  "minimum_qualifying_period": 1,
+            |  "address_postcode": "WS9 8LL",
+            |  "rre_to_consider": 1,
+            |  "pension_share_order_serps": 1,
+            |  "nino": "QQ123456A",
+            |  "earnings_included_upto": "2015-04-05"
+            |}
+          """.stripMargin).as[NpsSummary].reducedRateElection shouldBe true
+      }
+    }
+
     "parse the amounts correctly" in {
 
       summaryJson.as[NpsSummary].amounts shouldBe NpsStatePensionAmounts(
@@ -209,6 +276,7 @@ class NpsSummarySpec extends UnitSpec {
         )
       )
     }
+
   }
 
   "NpsAmounts" should {
@@ -467,6 +535,7 @@ class NpsSummarySpec extends UnitSpec {
       false,
       new LocalDate(1954, 3, 9),
       None,
+      false,
       NpsStatePensionAmounts(amountA2016 = NpsAmountA2016(), amountB2016 = NpsAmountB2016())
     )
 
@@ -507,6 +576,7 @@ class NpsSummarySpec extends UnitSpec {
       false,
       dateOfBirth,
       None,
+      false,
       NpsStatePensionAmounts(amountA2016 = NpsAmountA2016(), amountB2016 = NpsAmountB2016())
     )
 

--- a/test/uk/gov/hmrc/statepension/services/ExclusionServiceSpec.scala
+++ b/test/uk/gov/hmrc/statepension/services/ExclusionServiceSpec.scala
@@ -25,8 +25,8 @@ class ExclusionServiceSpec extends StatePensionUnitSpec {
   val exampleNow = new LocalDate(2017, 2, 16)
   val examplePensionDate = new LocalDate(2022, 2, 2)
 
-  def exclusionServiceBuilder(dateOfDeath: Option[LocalDate] = None, pensionDate: LocalDate = examplePensionDate, now: LocalDate = exampleNow) =
-    new ExclusionService(dateOfDeath, pensionDate, now)
+  def exclusionServiceBuilder(dateOfDeath: Option[LocalDate] = None, pensionDate: LocalDate = examplePensionDate, now: LocalDate = exampleNow, reducedRateElection: Boolean = false) =
+    new ExclusionService(dateOfDeath, pensionDate, now, reducedRateElection)
 
 
   "getExclusions" when {
@@ -62,8 +62,27 @@ class ExclusionServiceSpec extends StatePensionUnitSpec {
       }
     }
 
+    "there is reduced rate election" should {
+      "return a List(MarriwedWomensReducedRateElection" in {
+        exclusionServiceBuilder(reducedRateElection = true).getExclusions shouldBe List(Exclusion.MarriedWomenReducedRateElection)
+      }
+    }
+
+    "there is no reduced rate election" should {
+      "return no exclusions" in {
+        exclusionServiceBuilder(reducedRateElection = false).getExclusions shouldBe Nil
+      }
+    }
+
     "all the exclusion criteria are met" should {
-      exclusionServiceBuilder(dateOfDeath = Some(new LocalDate(1999, 12, 31)), pensionDate = new LocalDate(2000, 1, 1), now = new LocalDate(2000, 1, 1)).getExclusions shouldBe List(Exclusion.Dead, Exclusion.PostStatePensionAge)
+      "return a sorted list of Dead, PostSPA, MWRRE" in {
+        exclusionServiceBuilder(
+          dateOfDeath = Some(new LocalDate(1999, 12, 31)),
+          pensionDate = new LocalDate(2000, 1, 1),
+          now = new LocalDate(2000, 1, 1),
+          reducedRateElection = true
+        ).getExclusions shouldBe List(Exclusion.Dead, Exclusion.PostStatePensionAge, Exclusion.MarriedWomenReducedRateElection)
+      }
     }
   }
 

--- a/test/uk/gov/hmrc/statepension/services/ExclusionServiceSpec.scala
+++ b/test/uk/gov/hmrc/statepension/services/ExclusionServiceSpec.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.statepension.services
+
+import org.joda.time.LocalDate
+import uk.gov.hmrc.statepension.StatePensionUnitSpec
+import uk.gov.hmrc.statepension.domain.Exclusion
+
+class ExclusionServiceSpec extends StatePensionUnitSpec {
+
+  val exampleNow = new LocalDate(2017, 2, 16)
+  val examplePensionDate = new LocalDate(2022, 2, 2)
+
+  def exclusionServiceBuilder(dateOfDeath: Option[LocalDate] = None, pensionDate: LocalDate = examplePensionDate, now: LocalDate = exampleNow) =
+    new ExclusionService(dateOfDeath, pensionDate, now)
+
+
+  "getExclusions" when {
+    "there is no exclusions" should {
+      "return an empty list" in {
+        exclusionServiceBuilder(dateOfDeath = None).getExclusions shouldBe Nil
+      }
+    }
+
+    "there is a date of death" should {
+      "return a List(Dead)" in {
+        exclusionServiceBuilder(dateOfDeath = Some(new LocalDate(2000, 9, 13))).getExclusions shouldBe List(Exclusion.Dead)
+      }
+    }
+
+    "checking for post state pension age" should {
+      "return a List(PostStatePensionAge)" when {
+        "the state pension age is the same as the current date" in {
+          exclusionServiceBuilder(pensionDate = new LocalDate(2000, 1, 1), now = new LocalDate(2000, 1, 1)).getExclusions shouldBe List(Exclusion.PostStatePensionAge)
+        }
+        "the state pension age is one day after the the current date" in {
+          exclusionServiceBuilder(pensionDate = new LocalDate(2000, 1, 2), now = new LocalDate(2000, 1, 1)).getExclusions shouldBe List(Exclusion.PostStatePensionAge)
+        }
+        "the state pension age is one day before the the current date" in {
+          exclusionServiceBuilder(pensionDate = new LocalDate(2000, 1, 1), now = new LocalDate(2000, 1, 2)).getExclusions shouldBe List(Exclusion.PostStatePensionAge)
+        }
+      }
+
+      "return an empty list" when {
+        "the state pension age is two days after the current date" in {
+          exclusionServiceBuilder(pensionDate = new LocalDate(2000, 1, 3), now = new LocalDate(2000, 1, 1)).getExclusions shouldBe List()
+        }
+      }
+    }
+
+    "all the exclusion criteria are met" should {
+      exclusionServiceBuilder(dateOfDeath = Some(new LocalDate(1999, 12, 31)), pensionDate = new LocalDate(2000, 1, 1), now = new LocalDate(2000, 1, 1)).getExclusions shouldBe List(Exclusion.Dead, Exclusion.PostStatePensionAge)
+    }
+  }
+
+}


### PR DESCRIPTION
* Added an Exclusion service using the same pattern from nisp.
* Had to give the StatePensionService the concept of time for the SPA exclusion.
* Created a Country class to handle anything NPS Country code related
* Changed some unit test wording errors that @swaistle found.