### PR TITLE
NISP-2298: Add rest of Exclusions

### DIFF
--- a/app/uk/gov/hmrc/statepension/domain/nps/LiabilityType.scala
+++ b/app/uk/gov/hmrc/statepension/domain/nps/LiabilityType.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.statepension.domain.nps
+
+object LiabilityType {
+  final val ISLE_OF_MAN = 15
+}

--- a/app/uk/gov/hmrc/statepension/domain/nps/NpsLiability.scala
+++ b/app/uk/gov/hmrc/statepension/domain/nps/NpsLiability.scala
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.statepension.connectors
+package uk.gov.hmrc.statepension.domain.nps
 
-import uk.gov.hmrc.statepension.domain.nps.{NpsLiability, NpsSummary}
+import play.api.libs.json._
 
-import scala.concurrent.Future
+case class NpsLiability(liabilityType: Int)
 
-trait NpsConnector {
-    def getSummary: Future[NpsSummary]
-    def getLiabilities: Future[List[NpsLiability]]
+object NpsLiability {
+  implicit val reads: Reads[NpsLiability] = (__ \ "liability_type").read[Int].map(NpsLiability.apply)
 }

--- a/app/uk/gov/hmrc/statepension/services/CitizenDetailsService.scala
+++ b/app/uk/gov/hmrc/statepension/services/CitizenDetailsService.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.statepension.services
+
+import scala.concurrent.Future
+
+trait CitizenDetailsService {
+  def checkManualCorrespondenceIndicator: Future[Boolean]
+}

--- a/app/uk/gov/hmrc/statepension/services/ExclusionService.scala
+++ b/app/uk/gov/hmrc/statepension/services/ExclusionService.scala
@@ -22,6 +22,7 @@ import org.joda.time.LocalDate
 import play.Logger
 import uk.gov.hmrc.statepension.domain.Exclusion
 import uk.gov.hmrc.statepension.domain.Exclusion.Exclusion
+import uk.gov.hmrc.statepension.domain.nps.NpsLiability
 import uk.gov.hmrc.statepension.util.FunctionHelper
 
 class ExclusionService(dateOfDeath: Option[LocalDate],
@@ -32,7 +33,8 @@ class ExclusionService(dateOfDeath: Option[LocalDate],
                        sex: String,
                        entitlement: BigDecimal,
                        startingAmount: BigDecimal,
-                       calculatedStartingAmount: BigDecimal) {
+                       calculatedStartingAmount: BigDecimal,
+                       liabilities: List[NpsLiability]) {
 
   lazy val getExclusions: List[Exclusion] = exclusions(List())
 
@@ -54,6 +56,12 @@ class ExclusionService(dateOfDeath: Option[LocalDate],
       exclusionList
     }
 
+  final val ISLE_OF_MAN_LIABILITY = 15
+
+  private val checkIsleOfMan = (exclusionList: List[Exclusion]) =>
+    if (liabilities.exists(_.liabilityType == ISLE_OF_MAN_LIABILITY)) Exclusion.IsleOfMan :: exclusionList
+    else exclusionList
+
   private val checkMarriedWomensReducedRateElection = (exclusionList: List[Exclusion]) =>
     if (reducedRateElection) Exclusion.MarriedWomenReducedRateElection :: exclusionList else exclusionList
 
@@ -69,6 +77,6 @@ class ExclusionService(dateOfDeath: Option[LocalDate],
   }
 
   private val exclusions = FunctionHelper.composeAll(List(
-    checkDead, checkPostStatePensionAge, checkAmountDissonance, checkMarriedWomensReducedRateElection, checkOverseasMaleAutoCredits
+    checkDead, checkPostStatePensionAge, checkAmountDissonance, checkIsleOfMan, checkMarriedWomensReducedRateElection, checkOverseasMaleAutoCredits
   ))
 }

--- a/app/uk/gov/hmrc/statepension/services/ForecastingService.scala
+++ b/app/uk/gov/hmrc/statepension/services/ForecastingService.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.statepension.services
+
+object ForecastingService {
+
+  def calculateStartingAmount(amountA2016: BigDecimal, amountB2016: BigDecimal): BigDecimal = {
+    amountA2016.max(amountB2016)
+  }
+
+}

--- a/app/uk/gov/hmrc/statepension/services/StatePensionService.scala
+++ b/app/uk/gov/hmrc/statepension/services/StatePensionService.scala
@@ -61,7 +61,10 @@ trait NpsConnection extends StatePensionService {
         now,
         reducedRateElection = summary.reducedRateElection,
         isAbroad = Country.isAbroad(summary.countryCode),
-        sex = summary.sex
+        sex = summary.sex,
+        summary.amounts.pensionEntitlement,
+        summary.amounts.startingAmount2016,
+        ForecastingService.calculateStartingAmount(summary.amounts.amountA2016.total, summary.amounts.amountB2016.mainComponent)
       ).getExclusions
 
       if (exclusions.nonEmpty) {

--- a/test/uk/gov/hmrc/statepension/ForecastingServiceSpec.scala
+++ b/test/uk/gov/hmrc/statepension/ForecastingServiceSpec.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.statepension
+
+import uk.gov.hmrc.statepension.services.ForecastingService
+
+class ForecastingServiceSpec extends StatePensionUnitSpec {
+
+  "calculateStartingAmount" when {
+    "Amount A is higher than Amount B" should {
+      "return Amount A" in {
+        ForecastingService.calculateStartingAmount(100.00, 99.99) shouldBe 100
+      }
+    }
+
+    "Amount B is higher than Amount A" should {
+      "return Amount B" in {
+        ForecastingService.calculateStartingAmount(99.99, 100.00) shouldBe 100
+      }
+    }
+
+    "Amount B are equal Amount A" should {
+      "return the value" in {
+        ForecastingService.calculateStartingAmount(99, 99) shouldBe 99
+      }
+    }
+
+  }
+
+}

--- a/test/uk/gov/hmrc/statepension/domain/nps/LiabilityTypeSpec.scala
+++ b/test/uk/gov/hmrc/statepension/domain/nps/LiabilityTypeSpec.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.statepension.domain.nps
+
+import uk.gov.hmrc.statepension.StatePensionUnitSpec
+
+class LiabilityTypeSpec extends StatePensionUnitSpec {
+    "ISLE_OF_MAN" should {
+      "be 15" in {
+        LiabilityType.ISLE_OF_MAN shouldBe 15
+      }
+    }
+}

--- a/test/uk/gov/hmrc/statepension/domain/nps/NpsLiabilitySpec.scala
+++ b/test/uk/gov/hmrc/statepension/domain/nps/NpsLiabilitySpec.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.statepension.domain.nps
+
+import play.api.libs.json.Json
+import uk.gov.hmrc.statepension.StatePensionUnitSpec
+
+
+class NpsLiabilitySpec extends StatePensionUnitSpec {
+
+  "NpsLiability" should {
+    "parse liability type correctly" in {
+      Json.parse("""
+        |{
+        |    "liability_type_end_date": "2000-02-17",
+        |    "liability_occurrence_no": 1,
+        |    "liability_type_start_date": "1984-02-20",
+        |    "liability_type_end_date_reason": "END DATE HELD",
+        |    "liability_type": 16,
+        |    "nino": "QQ123456A",
+        |    "award_amount": null
+        |}
+      """.stripMargin).as[NpsLiability].liabilityType shouldBe 16
+    }
+  }
+}

--- a/test/uk/gov/hmrc/statepension/services/ExclusionServiceSpec.scala
+++ b/test/uk/gov/hmrc/statepension/services/ExclusionServiceSpec.scala
@@ -35,8 +35,9 @@ class ExclusionServiceSpec extends StatePensionUnitSpec {
                               entitlement: BigDecimal = 0,
                               startingAmount: BigDecimal = 0,
                               calculatedStartingAmount: BigDecimal = 0,
-                              liabilities: List[NpsLiability] = List()) =
-    new ExclusionService(dateOfDeath, pensionDate, now, reducedRateElection, isAbroad, sex, entitlement, startingAmount, calculatedStartingAmount, liabilities)
+                              liabilities: List[NpsLiability] = List(),
+                              manualCorrespondenceOnly: Boolean = false) =
+    new ExclusionService(dateOfDeath, pensionDate, now, reducedRateElection, isAbroad, sex, entitlement, startingAmount, calculatedStartingAmount, liabilities, manualCorrespondenceOnly)
 
 
   "getExclusions" when {
@@ -153,6 +154,18 @@ class ExclusionServiceSpec extends StatePensionUnitSpec {
       }
     }
 
+    "there is manual correspondence only" should {
+      "return List(ManualCorrespondenceIndicator)" in {
+        exclusionServiceBuilder(manualCorrespondenceOnly = true).getExclusions shouldBe List(Exclusion.ManualCorrespondenceIndicator)
+      }
+    }
+
+    "there is not manual correspondence only" should {
+      "return no exclusions" in {
+        exclusionServiceBuilder(manualCorrespondenceOnly = false).getExclusions shouldBe Nil
+      }
+    }
+
     "all the exclusion criteria are met" should {
       "return a sorted list of Dead, PostSPA, MWRRE" in {
         exclusionServiceBuilder(
@@ -165,9 +178,11 @@ class ExclusionServiceSpec extends StatePensionUnitSpec {
           entitlement = 100,
           startingAmount = 100,
           calculatedStartingAmount = 101,
-          liabilities = List(NpsLiability(15), NpsLiability(15), NpsLiability(1))
+          liabilities = List(NpsLiability(15), NpsLiability(15), NpsLiability(1)),
+          manualCorrespondenceOnly = true
         ).getExclusions shouldBe List(
           Exclusion.Dead,
+          Exclusion.ManualCorrespondenceIndicator,
           Exclusion.PostStatePensionAge,
           Exclusion.AmountDissonance,
           Exclusion.IsleOfMan,

--- a/test/uk/gov/hmrc/statepension/services/ExclusionServiceSpec.scala
+++ b/test/uk/gov/hmrc/statepension/services/ExclusionServiceSpec.scala
@@ -30,8 +30,11 @@ class ExclusionServiceSpec extends StatePensionUnitSpec {
                               now: LocalDate = exampleNow,
                               reducedRateElection: Boolean = false,
                               isAbroad: Boolean = false,
-                              sex: String = "F") =
-    new ExclusionService(dateOfDeath, pensionDate, now, reducedRateElection, isAbroad, sex)
+                              sex: String = "F",
+                              entitlement: BigDecimal = 0,
+                              startingAmount: BigDecimal = 0,
+                              calculatedStartingAmount: BigDecimal = 0) =
+    new ExclusionService(dateOfDeath, pensionDate, now, reducedRateElection, isAbroad, sex, entitlement, startingAmount, calculatedStartingAmount)
 
 
   "getExclusions" when {
@@ -119,6 +122,19 @@ class ExclusionServiceSpec extends StatePensionUnitSpec {
       }
     }
 
+    "the amount dissonance criteria is met" when  {
+      "the entitlement and calculatedStartingAmount are the same" should {
+        "return no exclusions" in {
+          exclusionServiceBuilder(entitlement = 155.65, startingAmount = 155.65, calculatedStartingAmount = 155.65).getExclusions shouldBe Nil
+        }
+      }
+      "the entitlement and calculatedStartingAmount are different" should {
+        "return List(AmountDissonance)" in {
+          exclusionServiceBuilder(entitlement = 155.65, startingAmount = 155.65, calculatedStartingAmount = 101).getExclusions shouldBe List(Exclusion.AmountDissonance)
+        }
+      }
+    }
+
     "all the exclusion criteria are met" should {
       "return a sorted list of Dead, PostSPA, MWRRE" in {
         exclusionServiceBuilder(
@@ -127,8 +143,11 @@ class ExclusionServiceSpec extends StatePensionUnitSpec {
           now = new LocalDate(2000, 1, 1),
           reducedRateElection = true,
           isAbroad = true,
-          sex = "M"
-        ).getExclusions shouldBe List(Exclusion.Dead, Exclusion.PostStatePensionAge, Exclusion.MarriedWomenReducedRateElection, Exclusion.Abroad)
+          sex = "M",
+          entitlement = 100,
+          startingAmount = 100,
+          calculatedStartingAmount = 101
+        ).getExclusions shouldBe List(Exclusion.Dead, Exclusion.PostStatePensionAge, Exclusion.AmountDissonance, Exclusion.MarriedWomenReducedRateElection, Exclusion.Abroad)
       }
     }
   }

--- a/test/uk/gov/hmrc/statepension/services/StatePensionServiceSpec.scala
+++ b/test/uk/gov/hmrc/statepension/services/StatePensionServiceSpec.scala
@@ -388,7 +388,7 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         }
       }
 
-      "have a pension date of 2050-7-7" in {
+      "have a pension date of 2016-1-1" in {
         whenReady(exclusionF) { exclusion =>
           exclusion.pensionDate shouldBe new LocalDate(2016, 1, 1)
         }
@@ -434,7 +434,7 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         }
       }
 
-      "have a pension date of 2050-7-7" in {
+      "have a pension date of 2018-1-1" in {
         whenReady(exclusionF) { exclusion =>
           exclusion.pensionDate shouldBe new LocalDate(2018, 1, 1)
         }
@@ -480,7 +480,7 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         }
       }
 
-      "have a pension date of 2050-7-7" in {
+      "have a pension date of 2018-1-1" in {
         whenReady(exclusionF) { exclusion =>
           exclusion.pensionDate shouldBe new LocalDate(2018, 1, 1)
         }
@@ -528,7 +528,7 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         }
       }
 
-      "have a pension date of 2050-7-7" in {
+      "have a pension date of 2018-1-1" in {
         whenReady(exclusionF) { exclusion =>
           exclusion.pensionDate shouldBe new LocalDate(2018, 1, 1)
         }


### PR DESCRIPTION
* Added liabilities to NPS Connector for IOM exclusion
* Added Forecasting Service to do anything maths related (I have a feeling revaluation will be added later to this method which why I didn't put it on the class)
* Added Citizen Details service for MCI check, there is no connector yet.

Still to do:
* Metrics and Auditing
* Forecasting
* Actual Connections to other microservices