### PR TITLE
NISP-2298: Add Forecast Amount

### DIFF
--- a/app/uk/gov/hmrc/statepension/controllers/live/StatePensionController.scala
+++ b/app/uk/gov/hmrc/statepension/controllers/live/StatePensionController.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.statepension.controllers.live
 
-import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.statepension.config.AppContext
 import uk.gov.hmrc.statepension.connectors.CustomAuditConnector
 import uk.gov.hmrc.statepension.controllers.StatePensionController

--- a/app/uk/gov/hmrc/statepension/services/ForecastingService.scala
+++ b/app/uk/gov/hmrc/statepension/services/ForecastingService.scala
@@ -16,10 +16,31 @@
 
 package uk.gov.hmrc.statepension.services
 
+import org.joda.time.LocalDate
+import uk.gov.hmrc.time.TaxYearResolver
+
+import scala.math.BigDecimal.RoundingMode
+
 object ForecastingService {
+
+  final val MINIMUM_QUALIFYING_YEARS = 10
 
   def calculateStartingAmount(amountA2016: BigDecimal, amountB2016: BigDecimal): BigDecimal = {
     amountA2016.max(amountB2016)
+  }
+
+  def calculateForecastAmount(earningsIncludedUpTo: LocalDate, finalRelevantStartYear: Int, currentAmount: BigDecimal, qualifyingYears: Int): BigDecimal = {
+    require(earningsIncludedUpTo.getYear >= 2016, "2015-16 tax year has not been posted")
+
+    val yearsLeft = yearsLeftToContribute(earningsIncludedUpTo, finalRelevantStartYear)
+
+    if(currentAmount >= RateService.MAX_AMOUNT) currentAmount
+    else if ((yearsLeft + qualifyingYears) < MINIMUM_QUALIFYING_YEARS) 0
+    else (currentAmount + RateService.spAmountPerYear * yearsLeft).setScale(2, RoundingMode.HALF_UP).min(RateService.MAX_AMOUNT)
+  }
+
+  def yearsLeftToContribute(earningsIncludedUpTo: LocalDate, finalRelevantStartYear: Int): Int  = {
+    (finalRelevantStartYear - TaxYearResolver.taxYearFor(earningsIncludedUpTo)).max(0)
   }
 
 }

--- a/app/uk/gov/hmrc/statepension/services/RateService.scala
+++ b/app/uk/gov/hmrc/statepension/services/RateService.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.statepension.services
+
+object RateService {
+
+  final val MAX_AMOUNT: BigDecimal = 155.65
+  final val MAX_YEARS: BigDecimal = 35
+
+  val spAmountPerYear: BigDecimal = MAX_AMOUNT / MAX_YEARS
+
+  def getSPAmount(totalQualifyingYears: Int): BigDecimal = {
+    if (totalQualifyingYears > MAX_YEARS) {
+      MAX_AMOUNT
+    } else {
+      spAmountPerYear * totalQualifyingYears
+    }
+  }
+
+}

--- a/app/uk/gov/hmrc/statepension/services/StatePensionService.scala
+++ b/app/uk/gov/hmrc/statepension/services/StatePensionService.scala
@@ -85,12 +85,21 @@ trait NpsConnection extends StatePensionService {
           pensionDate = summary.statePensionAgeDate
         ))
       } else {
+
+
+        val forecast = ForecastingService.calculateForecastAmount(
+          summary.earningsIncludedUpTo,
+          summary.finalRelevantStartYear,
+          summary.amounts.pensionEntitlement,
+          summary.qualifyingYears
+        )
+
         Right(StatePension(
           earningsIncludedUpTo = summary.earningsIncludedUpTo,
           amounts = StatePensionAmounts(
             summary.amounts.protectedPayment2016 > 0,
             StatePensionAmount(None, None, summary.amounts.pensionEntitlement),
-            StatePensionAmount(None, None, 0),
+            StatePensionAmount(None, None, forecast),
             StatePensionAmount(Some(0), None, 0),
             StatePensionAmount(Some(0), Some(0), summary.amounts.amountB2016.rebateDerivedAmount)
           ),

--- a/test/uk/gov/hmrc/statepension/services/RateServiceSpec.scala
+++ b/test/uk/gov/hmrc/statepension/services/RateServiceSpec.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.statepension.services
+
+import uk.gov.hmrc.statepension.StatePensionUnitSpec
+
+import scala.math.BigDecimal.RoundingMode
+
+class RateServiceSpec extends StatePensionUnitSpec {
+
+  "spAmountPerYear" should {
+    "return 4.32 (Maximum Amount - 155.65 divided by Maximum Years - 35" in {
+      RateService.spAmountPerYear.setScale(8, RoundingMode.HALF_UP) shouldBe BigDecimal(4.44714286)
+    }
+  }
+
+  "getSPAmount called" should {
+    "return None for no years" in {
+      RateService.getSPAmount(0) shouldBe 0
+    }
+
+    "return the maximum amount for a high number" in {
+      RateService.getSPAmount(100) shouldBe 155.65
+    }
+
+    "return the maximum amount for 35" in {
+      RateService.getSPAmount(35) shouldBe 155.65
+    }
+
+    "22 Qualifying years should return £97.84" in {
+      RateService.getSPAmount(22).setScale(10, RoundingMode.FLOOR) shouldBe BigDecimal((155.65/35)*22).setScale(10, RoundingMode.FLOOR)
+    }
+
+    "17 Qualifying years should return £75.60" in {
+      RateService.getSPAmount(17).setScale(10, RoundingMode.FLOOR) shouldBe BigDecimal((155.65/35)*17).setScale(10, RoundingMode.FLOOR)
+    }
+  }
+
+
+}


### PR DESCRIPTION
This PR adds the logic to do forecasting.

* This only needs the current amount.
* Pre-2016 forecasting has been dropped as it will not be required soon and is fairly huge.
* This is only the amount, the years left to work is still to come.
* Introduced a rate service, similar to the one in live.

Can @prashantchoudhari review the code and @swaistle or @Shaju-11 review my test cases to make sure they are enough for forecasting.

Still to do:
* years left to work
* personal maximum
* metrics / auditing
* connector code