### PR TITLE
NISP-2298: Add Personal Max Amount

### DIFF
--- a/app/uk/gov/hmrc/statepension/connectors/NpsConnector.scala
+++ b/app/uk/gov/hmrc/statepension/connectors/NpsConnector.scala
@@ -23,5 +23,5 @@ import scala.concurrent.Future
 trait NpsConnector {
     def getSummary: Future[NpsSummary]
     def getLiabilities: Future[List[NpsLiability]]
-    def getNIRecord: Future[List[NpsNIRecord]]
+    def getNIRecord: Future[NpsNIRecord]
 }

--- a/app/uk/gov/hmrc/statepension/domain/nps/NpsNIRecord.scala
+++ b/app/uk/gov/hmrc/statepension/domain/nps/NpsNIRecord.scala
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.statepension.connectors
+package uk.gov.hmrc.statepension.domain.nps
 
-import uk.gov.hmrc.statepension.domain.nps.{NpsLiability, NpsNIRecord, NpsSummary}
+import play.api.libs.json.{Reads, __}
 
-import scala.concurrent.Future
+case class NpsNIRecord(payableGaps: Int)
 
-trait NpsConnector {
-    def getSummary: Future[NpsSummary]
-    def getLiabilities: Future[List[NpsLiability]]
-    def getNIRecord: Future[List[NpsNIRecord]]
+object NpsNIRecord {
+  implicit val reads: Reads[NpsNIRecord] = (__ \ "non_qualifying_years_payable").read[Int].map(NpsNIRecord.apply)
 }

--- a/app/uk/gov/hmrc/statepension/services/ForecastingService.scala
+++ b/app/uk/gov/hmrc/statepension/services/ForecastingService.scala
@@ -49,8 +49,24 @@ object ForecastingService {
     }
   }
 
+  def calculatePersonalMaximum(earningsIncludedUpTo: LocalDate, finalRelevantStartYear: Int,
+                               qualifyingYears: Int, payableGaps: Int,
+                               additionalPension: BigDecimal, rebateDerivedAmount: BigDecimal): BigDecimal = {
+    val potentialYears = qualifyingYears + payableGaps
+    val startingAmount = calculateStartingAmount(amountA(potentialYears, additionalPension), amountB(potentialYears, rebateDerivedAmount))
+    calculateForecastAmount(earningsIncludedUpTo, finalRelevantStartYear, currentAmount = startingAmount, qualifyingYears).amount
+  }
+
   def yearsLeftToContribute(earningsIncludedUpTo: LocalDate, finalRelevantStartYear: Int): Int  = {
     (finalRelevantStartYear - TaxYearResolver.taxYearFor(earningsIncludedUpTo)).max(0)
+  }
+
+  def amountA(qualifyingYearsPre2016: Int, additionalPension: BigDecimal): BigDecimal = {
+    RateService.getBasicSPAmount(qualifyingYearsPre2016) + additionalPension
+  }
+
+  def amountB(qualfyingYears: Int, rebateDerivedAmount: BigDecimal): BigDecimal = {
+    RateService.getSPAmount(qualfyingYears) - rebateDerivedAmount
   }
 
 }

--- a/app/uk/gov/hmrc/statepension/services/RateService.scala
+++ b/app/uk/gov/hmrc/statepension/services/RateService.scala
@@ -16,6 +16,8 @@
 
 package uk.gov.hmrc.statepension.services
 
+import scala.math.BigDecimal.RoundingMode
+
 object RateService {
 
   final val MAX_AMOUNT: BigDecimal = 155.65
@@ -28,6 +30,19 @@ object RateService {
       MAX_AMOUNT
     } else {
       spAmountPerYear * totalQualifyingYears
+    }
+  }
+
+  final val MAX_BASIC_AMOUNT: BigDecimal = 119.30
+  final val MAX_BASIC_YEARS: Int = 30
+
+  val basicSPAmountPerYear: BigDecimal = MAX_BASIC_AMOUNT / MAX_BASIC_YEARS
+
+  def getBasicSPAmount(qualifyingYears: Int): BigDecimal = {
+    if (qualifyingYears > MAX_BASIC_YEARS) {
+      MAX_BASIC_AMOUNT
+    } else {
+      (basicSPAmountPerYear * qualifyingYears).setScale(2, RoundingMode.HALF_UP)
     }
   }
 

--- a/app/uk/gov/hmrc/statepension/services/StatePensionService.scala
+++ b/app/uk/gov/hmrc/statepension/services/StatePensionService.scala
@@ -57,10 +57,12 @@ trait NpsConnection extends StatePensionService {
     val summaryF = nps.getSummary
     val liablitiesF = nps.getLiabilities
     val manualCorrespondenceF = citizenDetailsService.checkManualCorrespondenceIndicator
+    val niRecordF = nps.getNIRecord
 
     for(
       summary <- summaryF;
       liablities <- liablitiesF;
+      niRecord <- niRecordF;
       manualCorrespondence <- manualCorrespondenceF
     ) yield {
 
@@ -98,7 +100,7 @@ trait NpsConnection extends StatePensionService {
           summary.earningsIncludedUpTo,
           summary.finalRelevantStartYear,
           summary.qualifyingYears,
-          payableGaps = 0,
+          payableGaps = niRecord.payableGaps,
           additionalPension = summary.amounts.amountA2016.totalAP,
           rebateDerivedAmount = summary.amounts.amountB2016.rebateDerivedAmount
         )

--- a/app/uk/gov/hmrc/statepension/services/StatePensionService.scala
+++ b/app/uk/gov/hmrc/statepension/services/StatePensionService.scala
@@ -94,14 +94,23 @@ trait NpsConnection extends StatePensionService {
           summary.qualifyingYears
         )
 
+        val personalMaximum = ForecastingService.calculatePersonalMaximum(
+          summary.earningsIncludedUpTo,
+          summary.finalRelevantStartYear,
+          summary.qualifyingYears,
+          payableGaps = 0,
+          additionalPension = summary.amounts.amountA2016.totalAP,
+          rebateDerivedAmount = summary.amounts.amountB2016.rebateDerivedAmount
+        )
+
         Right(StatePension(
           earningsIncludedUpTo = summary.earningsIncludedUpTo,
           amounts = StatePensionAmounts(
             summary.amounts.protectedPayment2016 > 0,
             StatePensionAmount(None, None, summary.amounts.pensionEntitlement),
             StatePensionAmount(Some(forecast.yearsToWork), None, forecast.amount),
-            StatePensionAmount(Some(0), None, 0),
-            StatePensionAmount(Some(0), Some(0), summary.amounts.amountB2016.rebateDerivedAmount)
+            StatePensionAmount(Some(0), None, personalMaximum),
+            StatePensionAmount(None, None, summary.amounts.amountB2016.rebateDerivedAmount)
           ),
           pensionAge = summary.statePensionAge,
           pensionDate = summary.statePensionAgeDate,

--- a/test/uk/gov/hmrc/statepension/ForecastingServiceSpec.scala
+++ b/test/uk/gov/hmrc/statepension/ForecastingServiceSpec.scala
@@ -175,15 +175,43 @@ class ForecastingServiceSpec extends StatePensionUnitSpec {
     }
 
     "there is one payable gap and zero years to contribute" when {
-      "when there is less than 30 qualifying years" should {
+      "there is less than 30 qualifying years" should {
         "return amount + 1 year of basic pension (119.3 /30)" in {
           maximumCalculation(new LocalDate(2016, 4, 5), 2015, 29, payableGaps = 1, rebateDerivedAmount = 100) shouldBe 119.30
         }
       }
-
-      "when there is 30 qualifying years" should {
+      "there is 30 qualifying years" should {
         "return the current amount" in {
           maximumCalculation(new LocalDate(2016, 4, 5), 2015, 30, payableGaps = 1, rebateDerivedAmount = 100) shouldBe 119.30
+        }
+      }
+      "there is 28 qualifying years" should {
+        "return the amount + 1 year of basic pension (119.3 /30) " in {
+          maximumCalculation(new LocalDate(2016, 4, 5), 2015, 28, payableGaps = 1, rebateDerivedAmount = 100) shouldBe 115.32
+        }
+      }
+    }
+
+    "there is one payable gap and one year to contribute " when {
+      "there is 29 qualifying years" should {
+        "return amount + 1 year of basic pension (119.3 /30) + 1 one year of state pension (155.65/35)" in {
+          maximumCalculation(new LocalDate(2016, 4, 5), 2016, 29, payableGaps = 1, rebateDerivedAmount = 100) shouldBe 123.75
+        }
+      }
+      "there is 30 qualifying years" should {
+        "return the current amount + 1 one year of state pension (155.65/35)" in {
+          maximumCalculation(new LocalDate(2016, 4, 5), 2016, 30, payableGaps = 1, rebateDerivedAmount = 100) shouldBe 123.75
+        }
+      }
+      "there is 28 qualifying years" should {
+        "return the amount + 1 year of basic pension (119.3 /30) + 1 one year of state pension (155.65/35) " in {
+          maximumCalculation(new LocalDate(2016, 4, 5), 2016, 28, payableGaps = 1, rebateDerivedAmount = 100) shouldBe 119.77
+        }
+      }
+
+      "there is 30 qualifying years and no RDA" should {
+        "return 32 qualifying years of new state pension" in {
+          maximumCalculation(new LocalDate(2016, 4, 5), 2016, 30, payableGaps = 1) shouldBe 142.31
         }
       }
     }

--- a/test/uk/gov/hmrc/statepension/domain/nps/NpsNIRecordSpec.scala
+++ b/test/uk/gov/hmrc/statepension/domain/nps/NpsNIRecordSpec.scala
@@ -1,0 +1,1099 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.statepension.domain.nps
+
+import play.api.libs.json.Json
+import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.statepension.StatePensionUnitSpec
+
+
+class NpsNIRecordSpec extends StatePensionUnitSpec {
+
+  "NpsLiability" should {
+    "parse liability type correctly" in {
+      Json.parse(
+        """
+          |{
+          |  "years_to_fry": 3,
+          |  "non_qualifying_years": 10,
+          |  "date_of_entry": "1969-08-01",
+          |  "npsLniemply": [],
+          |  "pre_75_cc_count": 250,
+          |  "number_of_qualifying_years": 36,
+          |  "npsErrlist": {
+          |    "count": 0,
+          |    "mgt_check": 0,
+          |    "commit_status": 2,
+          |    "npsErritem": [],
+          |    "bfm_return_code": 0,
+          |    "data_not_found": 0
+          |  },
+          |  "non_qualifying_years_payable": 5,
+          |  "npsLnitaxyr": [
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 1,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 1975,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": "1285.4500",
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": "70.6700",
+          |      "npsLothcred": [
+          |        {
+          |          "credit_source_type": 0,
+          |          "cc_type": 23,
+          |          "no_of_credits_and_conts": 20
+          |        },
+          |        {
+          |          "credit_source_type": 24,
+          |          "cc_type": 23,
+          |          "no_of_credits_and_conts": 6
+          |        }
+          |      ],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 1,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 1976,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": "932.1700",
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": "53.5000",
+          |      "npsLothcred": [
+          |        {
+          |          "credit_source_type": 0,
+          |          "cc_type": 23,
+          |          "no_of_credits_and_conts": 4
+          |        },
+          |        {
+          |          "credit_source_type": 24,
+          |          "cc_type": 23,
+          |          "no_of_credits_and_conts": 30
+          |        }
+          |      ],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 1,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 1977,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": "1433.0400",
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": "82.1300",
+          |      "npsLothcred": [
+          |        {
+          |          "credit_source_type": 24,
+          |          "cc_type": 23,
+          |          "no_of_credits_and_conts": 28
+          |        }
+          |      ],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 1,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 1978,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": "1069.2300",
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": "69.3500",
+          |      "npsLothcred": [
+          |        {
+          |          "credit_source_type": 24,
+          |          "cc_type": 23,
+          |          "no_of_credits_and_conts": 41
+          |        }
+          |      ],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 1,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 1979,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": "383.0800",
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": "24.9000",
+          |      "npsLothcred": [
+          |        {
+          |          "credit_source_type": 24,
+          |          "cc_type": 23,
+          |          "no_of_credits_and_conts": 42
+          |        }
+          |      ],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 1,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 1980,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": "1691.8500",
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": "114.1900",
+          |      "npsLothcred": [
+          |        {
+          |          "credit_source_type": 24,
+          |          "cc_type": 23,
+          |          "no_of_credits_and_conts": 35
+          |        }
+          |      ],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 1,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 1981,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": null,
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": null,
+          |      "npsLothcred": [
+          |        {
+          |          "credit_source_type": 24,
+          |          "cc_type": 23,
+          |          "no_of_credits_and_conts": 52
+          |        }
+          |      ],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 1,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 1982,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": null,
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": null,
+          |      "npsLothcred": [
+          |        {
+          |          "credit_source_type": 24,
+          |          "cc_type": 23,
+          |          "no_of_credits_and_conts": 52
+          |        }
+          |      ],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 0,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 1983,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": "197.7800",
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": "17.7600",
+          |      "npsLothcred": [
+          |        {
+          |          "credit_source_type": 24,
+          |          "cc_type": 23,
+          |          "no_of_credits_and_conts": 44
+          |        }
+          |      ],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 1,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 1984,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": "2658.8900",
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": "239.2100",
+          |      "npsLothcred": [
+          |        {
+          |          "credit_source_type": 24,
+          |          "cc_type": 23,
+          |          "no_of_credits_and_conts": 19
+          |        }
+          |      ],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 0,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 1985,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": null,
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": null,
+          |      "npsLothcred": [
+          |        {
+          |          "credit_source_type": 24,
+          |          "cc_type": 23,
+          |          "no_of_credits_and_conts": 34
+          |        }
+          |      ],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 0,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 1986,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": "720.8000",
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": "36.0400",
+          |      "npsLothcred": [
+          |        {
+          |          "credit_source_type": 24,
+          |          "cc_type": 23,
+          |          "no_of_credits_and_conts": 3
+          |        }
+          |      ],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 1,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 1987,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": null,
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": null,
+          |      "npsLothcred": [
+          |        {
+          |          "credit_source_type": 25,
+          |          "cc_type": 24,
+          |          "no_of_credits_and_conts": 52
+          |        }
+          |      ],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 1,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 1988,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": null,
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": null,
+          |      "npsLothcred": [
+          |        {
+          |          "credit_source_type": 25,
+          |          "cc_type": 24,
+          |          "no_of_credits_and_conts": 52
+          |        }
+          |      ],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 1,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 1989,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": "13624.0000",
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": "1149.9800",
+          |      "npsLothcred": [],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 1,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 1990,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": "11180.0000",
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": "840.8400",
+          |      "npsLothcred": [],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 1,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 1991,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": "14144.0000",
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": "1085.7600",
+          |      "npsLothcred": [],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 1,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 1992,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": "19448.0000",
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": "1555.8400",
+          |      "npsLothcred": [],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 1,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 1993,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": "13312.0000",
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": "996.3200",
+          |      "npsLothcred": [],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 1,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 1994,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": "23452.0000",
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": "2094.0400",
+          |      "npsLothcred": [],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 0,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 1995,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": null,
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": null,
+          |      "npsLothcred": [],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 0,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 1996,
+          |      "ni_earnings": null,
+          |      "amount_needed": "     ",
+          |      "primary_paid_earnings": null,
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": null,
+          |      "npsLothcred": [],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 1,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 1997,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": "23452.0000",
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": "2094.0400",
+          |      "npsLothcred": [],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 1,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 1998,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": "3912.0000",
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": "311.4400",
+          |      "npsLothcred": [],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 1,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 1999,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": "10311.0000",
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": "860.9900",
+          |      "npsLothcred": [
+          |        {
+          |          "credit_source_type": 29,
+          |          "cc_type": 23,
+          |          "no_of_credits_and_conts": 1
+          |        }
+          |      ],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 1,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 2000,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": "13779.0000",
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": "1111.9500",
+          |      "npsLothcred": [
+          |        {
+          |          "credit_source_type": 27,
+          |          "cc_type": 23,
+          |          "no_of_credits_and_conts": 2
+          |        }
+          |      ],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": "2008-04-05",
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 0,
+          |      "under_investigation_flag": 1,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 1,
+          |      "rattd_tax_year": 2001,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": "230.0000",
+          |      "class_three_payable": 0.0,
+          |      "ni_earnings_employed": "14.3000",
+          |      "npsLothcred": [
+          |        {
+          |          "credit_source_type": 22,
+          |          "cc_type": 23,
+          |          "no_of_credits_and_conts": 7
+          |        }
+          |      ],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 1,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 2002,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": null,
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": null,
+          |      "npsLothcred": [
+          |        {
+          |          "credit_source_type": 22,
+          |          "cc_type": 23,
+          |          "no_of_credits_and_conts": 52
+          |        }
+          |      ],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 1,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 2003,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": null,
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": null,
+          |      "npsLothcred": [
+          |        {
+          |          "credit_source_type": 22,
+          |          "cc_type": 23,
+          |          "no_of_credits_and_conts": 53
+          |        }
+          |      ],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 1,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 2004,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": "30000.0000",
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": "2779.4800",
+          |      "npsLothcred": [],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 1,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 2005,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": null,
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": null,
+          |      "npsLothcred": [
+          |        {
+          |          "credit_source_type": 22,
+          |          "cc_type": 23,
+          |          "no_of_credits_and_conts": 52
+          |        }
+          |      ],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 1,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 2006,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": null,
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": null,
+          |      "npsLothcred": [
+          |        {
+          |          "credit_source_type": 22,
+          |          "cc_type": 23,
+          |          "no_of_credits_and_conts": 52
+          |        }
+          |      ],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 1,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 2007,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": null,
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": null,
+          |      "npsLothcred": [
+          |        {
+          |          "credit_source_type": 22,
+          |          "cc_type": 23,
+          |          "no_of_credits_and_conts": 52
+          |        }
+          |      ],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": "2023-04-05",
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 0,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 1,
+          |      "rattd_tax_year": 2008,
+          |      "ni_earnings": null,
+          |      "amount_needed": "675.7500",
+          |      "primary_paid_earnings": null,
+          |      "class_three_payable": 675.75,
+          |      "ni_earnings_employed": null,
+          |      "npsLothcred": [
+          |        {
+          |          "credit_source_type": 27,
+          |          "cc_type": 23,
+          |          "no_of_credits_and_conts": 1
+          |        }
+          |      ],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": "2019-04-05",
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 1,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 2009,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": null,
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": null,
+          |      "npsLothcred": [
+          |        {
+          |          "credit_source_type": 25,
+          |          "cc_type": 24,
+          |          "no_of_credits_and_conts": 52
+          |        }
+          |      ],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": "2023-04-05",
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 0,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 1,
+          |      "rattd_tax_year": 2010,
+          |      "ni_earnings": null,
+          |      "amount_needed": "578.4000",
+          |      "primary_paid_earnings": null,
+          |      "class_three_payable": 578.4,
+          |      "ni_earnings_employed": null,
+          |      "npsLothcred": [
+          |        {
+          |          "credit_source_type": 27,
+          |          "cc_type": 23,
+          |          "no_of_credits_and_conts": 4
+          |        }
+          |      ],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": "2019-04-05",
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": "2023-04-05",
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 0,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 1,
+          |      "rattd_tax_year": 2011,
+          |      "ni_earnings": null,
+          |      "amount_needed": "655.2000",
+          |      "primary_paid_earnings": null,
+          |      "class_three_payable": 655.2,
+          |      "ni_earnings_employed": null,
+          |      "npsLothcred": [],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": "2019-04-05",
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": "2023-04-05",
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 0,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 1,
+          |      "rattd_tax_year": 2012,
+          |      "ni_earnings": null,
+          |      "amount_needed": "530.0000",
+          |      "primary_paid_earnings": null,
+          |      "class_three_payable": 530.0,
+          |      "ni_earnings_employed": null,
+          |      "npsLothcred": [
+          |        {
+          |          "credit_source_type": 27,
+          |          "cc_type": 23,
+          |          "no_of_credits_and_conts": 12
+          |        }
+          |      ],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": "2019-04-05",
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 1,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 2013,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": "28000.0000",
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": "2430.2400",
+          |      "npsLothcred": [],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    },
+          |    {
+          |      "class_three_payable_by_penalty": null,
+          |      "class_two_outstanding_weeks": null,
+          |      "class_two_payable": null,
+          |      "qualifying": 1,
+          |      "under_investigation_flag": 0,
+          |      "class_two_payable_by": null,
+          |      "co_class_one_paid": null,
+          |      "class_two_payable_by_penalty": null,
+          |      "co_primary_paid_earnings": null,
+          |      "payable": 0,
+          |      "rattd_tax_year": 2014,
+          |      "ni_earnings": null,
+          |      "amount_needed": null,
+          |      "primary_paid_earnings": "28000.0000",
+          |      "class_three_payable": null,
+          |      "ni_earnings_employed": "2430.2400",
+          |      "npsLothcred": [],
+          |      "ni_earnings_self_employed": null,
+          |      "class_three_payable_by": null,
+          |      "ni_earnings_voluntary": null
+          |    }
+          |  ],
+          |  "nino": "QQ123456A"
+          |}
+        """.stripMargin).as[NpsNIRecord].payableGaps shouldBe 5
+    }
+  }
+}

--- a/test/uk/gov/hmrc/statepension/services/RateServiceSpec.scala
+++ b/test/uk/gov/hmrc/statepension/services/RateServiceSpec.scala
@@ -42,11 +42,41 @@ class RateServiceSpec extends StatePensionUnitSpec {
     }
 
     "22 Qualifying years should return £97.84" in {
-      RateService.getSPAmount(22).setScale(10, RoundingMode.FLOOR) shouldBe BigDecimal((155.65/35)*22).setScale(10, RoundingMode.FLOOR)
+      RateService.getSPAmount(22).setScale(10, RoundingMode.FLOOR) shouldBe BigDecimal((155.65 / 35) * 22).setScale(10, RoundingMode.FLOOR)
     }
 
     "17 Qualifying years should return £75.60" in {
-      RateService.getSPAmount(17).setScale(10, RoundingMode.FLOOR) shouldBe BigDecimal((155.65/35)*17).setScale(10, RoundingMode.FLOOR)
+      RateService.getSPAmount(17).setScale(10, RoundingMode.FLOOR) shouldBe BigDecimal((155.65 / 35) * 17).setScale(10, RoundingMode.FLOOR)
+    }
+  }
+
+  "getBasicSPAmount called" should {
+    "return none for no years" in {
+      RateService.getBasicSPAmount(0) shouldBe 0
+    }
+
+    "return 119.30 for 30 years" in {
+      RateService.getBasicSPAmount(30) shouldBe 119.30
+    }
+
+    "return 119.30 for 31 years" in {
+      RateService.getBasicSPAmount(31) shouldBe 119.30
+    }
+
+    "return 99.42 for 25 years" in {
+      RateService.getBasicSPAmount(25) shouldBe 99.42
+    }
+
+    "return 87.49 for 22 years" in {
+      RateService.getBasicSPAmount(22) shouldBe 87.49
+    }
+
+    "return 39.77 for 10 years" in {
+      RateService.getBasicSPAmount(10) shouldBe 39.77
+    }
+
+    "return 3.98 for 1 year" in {
+      RateService.getBasicSPAmount(1) shouldBe 3.98
     }
   }
 

--- a/test/uk/gov/hmrc/statepension/services/StatePensionServiceSpec.scala
+++ b/test/uk/gov/hmrc/statepension/services/StatePensionServiceSpec.scala
@@ -161,6 +161,10 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
           List()
         ))
 
+        when(service.nps.getNIRecord).thenReturn(Future.successful(
+          NpsNIRecord(payableGaps = 0)
+        ))
+
          val statement: Future[StatePension] = service.getStatement(generateNino()).right.get
 
         "return earningsIncludedUpTo of 2016-4-5" in {
@@ -376,6 +380,10 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         List()
       ))
 
+      when(service.nps.getNIRecord).thenReturn(Future.successful(
+        NpsNIRecord(payableGaps = 0)
+      ))
+
       lazy val statement: Future[StatePension] = service.getStatement(generateNino()).right.get
 
       "the forecast amount" should {
@@ -445,20 +453,24 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         List()
       ))
 
+      when(service.nps.getNIRecord).thenReturn(Future.successful(
+        NpsNIRecord(payableGaps = 2)
+      ))
+
       lazy val statement: Future[StatePension] = service.getStatement(generateNino()).right.get
 
       "the personal maximum amount" should {
 
-        "return a weekly forecast amount of 134.75" in {
-          statement.amounts.maximum.weeklyAmount shouldBe 134.75
+        "return a weekly forecast amount of 142.71" in {
+          statement.amounts.maximum.weeklyAmount shouldBe 142.71
         }
 
-        "return a monthly forecast amount of 585.92" in {
-          statement.amounts.maximum.monthlyAmount shouldBe 585.92
+        "return a monthly forecast amount of 620.53" in {
+          statement.amounts.maximum.monthlyAmount shouldBe 620.53
         }
 
-        "return an annual forecast amount of 7031.06" in {
-          statement.amounts.maximum.annualAmount shouldBe 7031.06
+        "return an annual forecast amount of 7446.40" in {
+          statement.amounts.maximum.annualAmount shouldBe 7446.40
         }
       }
     }
@@ -485,6 +497,9 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         NpsStatePensionAmounts()
       )
 
+      when(service.nps.getNIRecord).thenReturn(Future.successful(
+        NpsNIRecord(payableGaps = 2)
+      ))
 
       when(service.nps.getSummary).thenReturn(Future.successful(
         summary
@@ -545,6 +560,10 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         List()
       ))
 
+      when(service.nps.getNIRecord).thenReturn(Future.successful(
+        NpsNIRecord(payableGaps = 2)
+      ))
+
       lazy val exclusionF: Future[StatePensionExclusion] = service.getStatement(generateNino()).left.get
 
       "return post state pension age exclusion" in {
@@ -587,7 +606,6 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         NpsStatePensionAmounts()
       )
 
-
       when(service.nps.getSummary).thenReturn(Future.successful(
         summary
       ))
@@ -596,6 +614,9 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         List()
       ))
 
+      when(service.nps.getNIRecord).thenReturn(Future.successful(
+        NpsNIRecord(payableGaps = 2)
+      ))
 
       lazy val exclusionF: Future[StatePensionExclusion] = service.getStatement(generateNino()).left.get
 
@@ -645,6 +666,9 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
       ))
       when(service.nps.getLiabilities).thenReturn(Future.successful(
         List()
+      ))
+      when(service.nps.getNIRecord).thenReturn(Future.successful(
+        NpsNIRecord(payableGaps = 2)
       ))
 
       lazy val exclusionF: Future[StatePensionExclusion] = service.getStatement(generateNino()).left.get
@@ -698,7 +722,9 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
       when(service.nps.getLiabilities).thenReturn(Future.successful(
         List()
       ))
-
+      when(service.nps.getNIRecord).thenReturn(Future.successful(
+        NpsNIRecord(payableGaps = 2)
+      ))
 
       lazy val exclusionF: Future[StatePensionExclusion] = service.getStatement(generateNino()).left.get
 
@@ -743,6 +769,9 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
       ))
       when(service.nps.getLiabilities).thenReturn(Future.successful(
         List(NpsLiability(15))
+      ))
+      when(service.nps.getNIRecord).thenReturn(Future.successful(
+        NpsNIRecord(payableGaps = 2)
       ))
 
 
@@ -791,6 +820,9 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         List()
       ))
       when(service.citizenDetailsService.checkManualCorrespondenceIndicator).thenReturn(Future.successful(true))
+      when(service.nps.getNIRecord).thenReturn(Future.successful(
+        NpsNIRecord(payableGaps = 2)
+      ))
 
       lazy val exclusionF: Future[StatePensionExclusion] = service.getStatement(generateNino()).left.get
 


### PR DESCRIPTION
This PR adds the personal max amount.
The NIRecord API is required to get the number of payable gaps.

Still to do:
* Personal Max - Years to work
* Personal Max - Years to fill
* Metrics / Audits
* Connect to HOD