### PR TITLE
NISP-2298: Add Metrics

### DIFF
--- a/app/uk/gov/hmrc/statepension/domain/Scenario.scala
+++ b/app/uk/gov/hmrc/statepension/domain/Scenario.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.statepension.domain
+
+sealed trait Scenario
+object Scenario {
+  case object Reached extends Scenario
+  case object ContinueWorkingMax extends Scenario
+  case object ContinueWorkingNonMax extends Scenario
+  case object FillGaps extends Scenario
+  case object ForecastOnly extends Scenario
+  case object CantGetPension extends Scenario
+}
+
+sealed trait MQPScenario
+object MQPScenario {
+  case object ContinueWorking extends MQPScenario
+  case object CantGet extends MQPScenario
+  case object CanGetWithGaps extends MQPScenario
+}

--- a/app/uk/gov/hmrc/statepension/domain/nps/APIType.scala
+++ b/app/uk/gov/hmrc/statepension/domain/nps/APIType.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.statepension.domain.nps
+
+sealed trait APIType
+object APIType {
+  case object Summary extends APIType
+  case object NIRecord extends APIType
+  case object Liabilities extends APIType
+  case object CitizenDetails extends APIType
+}

--- a/app/uk/gov/hmrc/statepension/domain/nps/NpsSummary.scala
+++ b/app/uk/gov/hmrc/statepension/domain/nps/NpsSummary.scala
@@ -63,7 +63,6 @@ case class NpsStatePensionAmounts(
                                    pensionEntitlement: BigDecimal = 0,
                                    startingAmount2016: BigDecimal = 0,
                                    protectedPayment2016: BigDecimal = 0,
-                                   additionalPensionAccruedLastTaxYear: BigDecimal = 0,
                                    amountA2016: NpsAmountA2016 = NpsAmountA2016(),
                                    amountB2016: NpsAmountB2016 = NpsAmountB2016()
                                  )
@@ -77,7 +76,6 @@ object NpsStatePensionAmounts {
     readBigDecimal(JsPath \ "nsp_entitlement") and
       readBigDecimal(JsPath \ "starting_amount") and
       readBigDecimal(JsPath \ "protected_payment_2016") and
-      readBigDecimal(JsPath \ "ap_amount") and
       (JsPath \ "npsAmnapr16").read[NpsAmountA2016] and
       (JsPath \ "npsAmnbpr16").read[NpsAmountB2016]
     ) (NpsStatePensionAmounts.apply _)

--- a/app/uk/gov/hmrc/statepension/services/Metrics.scala
+++ b/app/uk/gov/hmrc/statepension/services/Metrics.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.statepension.services
+
+import com.codahale.metrics.Timer.Context
+import com.codahale.metrics.{Counter, Histogram, Timer}
+import com.kenshoo.play.metrics.MetricsRegistry
+import uk.gov.hmrc.statepension.domain.Exclusion.Exclusion
+import uk.gov.hmrc.statepension.domain.nps.APIType
+import uk.gov.hmrc.statepension.domain.{Exclusion, MQPScenario, Scenario}
+
+trait Metrics {
+  def startTimer(api: APIType): Timer.Context
+  def incrementFailedCounter(api: APIType): Unit
+
+  def summary(forecast: BigDecimal, current: BigDecimal, contractedOut: Boolean, forecastScenario: Scenario,
+              personalMaximum: BigDecimal, yearsToContribute: Int, mqpScenario: Option[MQPScenario]): Unit
+
+  def exclusion(exclusion: Exclusion): Unit
+}
+
+object Metrics extends Metrics {
+
+  val timers: Map[APIType, Timer] = Map(
+    APIType.Summary -> MetricsRegistry.defaultRegistry.timer("summary-response-timer"),
+    APIType.NIRecord -> MetricsRegistry.defaultRegistry.timer("nirecord-response-timer"),
+    APIType.Liabilities -> MetricsRegistry.defaultRegistry.timer("liabilities-response-timer"),
+    APIType.CitizenDetails -> MetricsRegistry.defaultRegistry.timer("citizen-details-timer")
+  )
+
+  val failedCounters: Map[APIType, Counter] = Map(
+    APIType.Summary -> MetricsRegistry.defaultRegistry.counter("summary-failed-counter"),
+    APIType.NIRecord -> MetricsRegistry.defaultRegistry.counter("nirecord-failed-counter"),
+    APIType.Liabilities -> MetricsRegistry.defaultRegistry.counter("liabilities-failed-counter")
+  )
+
+  override def startTimer(api: APIType): Context = timers(api).time()
+  override def incrementFailedCounter(api: APIType): Unit = failedCounters(api).inc()
+
+  val forecastScenarioMeters: Map[Scenario, Counter] = Map(
+    Scenario.Reached -> MetricsRegistry.defaultRegistry.counter("forecastscenario-reached"),
+    Scenario.ContinueWorkingMax -> MetricsRegistry.defaultRegistry.counter("forecastscenario-continueworkingmax"),
+    Scenario.ContinueWorkingNonMax -> MetricsRegistry.defaultRegistry.counter("forecastscenario-continueworkingnonmax"),
+    Scenario.FillGaps -> MetricsRegistry.defaultRegistry.counter("forecastscenario-fillgaps"),
+    Scenario.ForecastOnly -> MetricsRegistry.defaultRegistry.counter("forecastscenario-forecastonly"),
+    Scenario.CantGetPension -> MetricsRegistry.defaultRegistry.counter("forecastscenario-cantgetpension")
+  )
+
+  val mqpScenarioMeters: Map[MQPScenario, Counter] = Map(
+    MQPScenario.CantGet -> MetricsRegistry.defaultRegistry.counter("mqpscenario-cantget"),
+    MQPScenario.ContinueWorking -> MetricsRegistry.defaultRegistry.counter("mqpscenario-continueworking"),
+    MQPScenario.CanGetWithGaps -> MetricsRegistry.defaultRegistry.counter("mqpscenario-cangetwithgaps")
+  )
+
+  val currentAmountMeter: Histogram = MetricsRegistry.defaultRegistry.histogram("current-amount")
+  val forecastAmountMeter: Histogram = MetricsRegistry.defaultRegistry.histogram("forecast-amount")
+  val personalMaxAmountMeter: Histogram = MetricsRegistry.defaultRegistry.histogram("personal-maximum-amount")
+  val yearsNeededToContribute: Histogram = MetricsRegistry.defaultRegistry.histogram("years-needed-to-contribute")
+  val contractedOutMeter: Counter = MetricsRegistry.defaultRegistry.counter("contracted-out")
+  val notContractedOutMeter: Counter = MetricsRegistry.defaultRegistry.counter("not-contracted-out")
+
+  override def summary(forecast: BigDecimal, current: BigDecimal, contractedOut: Boolean,
+                       forecastScenario: Scenario, personalMaximum: BigDecimal, yearsToContribute: Int,
+                       mqpScenario : Option[MQPScenario]): Unit = {
+    forecastAmountMeter.update(forecast.toInt)
+    currentAmountMeter.update(current.toInt)
+    personalMaxAmountMeter.update(personalMaximum.toInt)
+    forecastScenarioMeters(forecastScenario).inc()
+    mqpScenario.foreach(mqpScenarioMeters(_).inc())
+    yearsNeededToContribute.update(yearsToContribute)
+    if(contractedOut) contractedOutMeter.inc() else notContractedOutMeter.inc()
+  }
+
+
+  val exclusionMeters: Map[Exclusion, Counter] = Map(
+    Exclusion.Abroad -> MetricsRegistry.defaultRegistry.counter("exclusion-abroad"),
+    Exclusion.MarriedWomenReducedRateElection -> MetricsRegistry.defaultRegistry.counter("exclusion-mwrre"),
+    Exclusion.Dead -> MetricsRegistry.defaultRegistry.counter("exclusion-dead"),
+    Exclusion.IsleOfMan -> MetricsRegistry.defaultRegistry.counter("exclusion-isle-of-man"),
+    Exclusion.AmountDissonance -> MetricsRegistry.defaultRegistry.counter("amount-dissonance"),
+    Exclusion.PostStatePensionAge -> MetricsRegistry.defaultRegistry.counter("exclusion-post-spa"),
+    Exclusion.ManualCorrespondenceIndicator -> MetricsRegistry.defaultRegistry.counter("exclusion-manual-correspondence")
+  )
+
+  override def exclusion(exclusion: Exclusion): Unit = exclusionMeters(exclusion).inc()
+}

--- a/app/uk/gov/hmrc/statepension/services/StatePensionService.scala
+++ b/app/uk/gov/hmrc/statepension/services/StatePensionService.scala
@@ -157,7 +157,7 @@ trait NpsConnection extends StatePensionService {
     } else if (exclusions.contains(Exclusion.MarriedWomenReducedRateElection)) {
       Exclusion.MarriedWomenReducedRateElection
     } else if (exclusions.contains(Exclusion.Abroad)) {
-      Exclusion.Dead
+      Exclusion.Abroad
     } else {
       throw new RuntimeException(s"Un-accounted for exclusion in NpsConnection: $exclusions")
     }

--- a/app/uk/gov/hmrc/statepension/services/StatePensionService.scala
+++ b/app/uk/gov/hmrc/statepension/services/StatePensionService.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.statepension.services
 
 import java.util.TimeZone
 
-import org.joda.time.{DateTimeZone, LocalDate}
+import org.joda.time.{DateTimeZone, LocalDate, Period, PeriodType}
 import play.api.Logger
 import play.api.libs.json.Json
 import uk.gov.hmrc.domain.Nino
@@ -53,6 +53,8 @@ trait NpsConnection extends StatePensionService {
 
   def now: LocalDate
 
+  def metrics: Metrics
+
   final val FULL_RATE = 155.65
 
   override def getStatement(nino: Nino)(implicit hc: HeaderCarrier): Future[Either[StatePensionExclusion, StatePension]] = {
@@ -84,13 +86,15 @@ trait NpsConnection extends StatePensionService {
       ).getExclusions
 
       if (exclusions.nonEmpty) {
+
+        metrics.exclusion(filterExclusions(exclusions))
+
         Left(StatePensionExclusion(
           exclusionReasons = exclusions,
           pensionAge = summary.statePensionAge,
           pensionDate = summary.statePensionAgeDate
         ))
       } else {
-
 
         val forecast = ForecastingService.calculateForecastAmount(
           summary.earningsIncludedUpTo,
@@ -108,7 +112,7 @@ trait NpsConnection extends StatePensionService {
           rebateDerivedAmount = summary.amounts.amountB2016.rebateDerivedAmount
         )
 
-        Right(StatePension(
+        val statePension = StatePension(
           earningsIncludedUpTo = summary.earningsIncludedUpTo,
           amounts = StatePensionAmounts(
             summary.amounts.protectedPayment2016 > 0,
@@ -123,8 +127,39 @@ trait NpsConnection extends StatePensionService {
           numberOfQualifyingYears = 36,
           pensionSharingOrder = summary.pensionSharingOrderSERPS,
           currentFullWeeklyPensionAmount = FULL_RATE
-        ))
+        )
+
+        metrics.summary(
+          statePension.amounts.forecast.weeklyAmount,
+          statePension.amounts.current.weeklyAmount,
+          statePension.amounts.cope.weeklyAmount > 0,
+          statePension.forecastScenario,
+          statePension.amounts.maximum.weeklyAmount,
+          statePension.amounts.forecast.yearsToWork.getOrElse(0),
+          statePension.mqpScenario
+        )
+        Right(statePension)
       }
+    }
+  }
+
+  private[services] def filterExclusions(exclusions: List[Exclusion]): Exclusion = {
+    if (exclusions.contains(Exclusion.Dead)) {
+      Exclusion.Dead
+    } else if (exclusions.contains(Exclusion.ManualCorrespondenceIndicator)) {
+      Exclusion.ManualCorrespondenceIndicator
+    } else if (exclusions.contains(Exclusion.PostStatePensionAge)) {
+      Exclusion.PostStatePensionAge
+    } else if (exclusions.contains(Exclusion.AmountDissonance)) {
+      Exclusion.AmountDissonance
+    } else if (exclusions.contains(Exclusion.IsleOfMan)) {
+      Exclusion.IsleOfMan
+    } else if (exclusions.contains(Exclusion.MarriedWomenReducedRateElection)) {
+      Exclusion.MarriedWomenReducedRateElection
+    } else if (exclusions.contains(Exclusion.Abroad)) {
+      Exclusion.Dead
+    } else {
+      throw new RuntimeException(s"Un-accounted for exclusion in NpsConnection: $exclusions")
     }
   }
 }
@@ -134,6 +169,7 @@ object StatePensionServiceViaNisp extends StatePensionService with NispConnectio
 object StatePensionService extends StatePensionService with NpsConnection {
   override lazy val nps: NpsConnector = ???
   override lazy val citizenDetailsService: CitizenDetailsService = ???
+  override lazy val metrics: Metrics = Metrics
 
   override def now: LocalDate = LocalDate.now(DateTimeZone.forTimeZone(TimeZone.getTimeZone("Europe/London")))
 }

--- a/app/uk/gov/hmrc/statepension/services/StatePensionService.scala
+++ b/app/uk/gov/hmrc/statepension/services/StatePensionService.scala
@@ -132,7 +132,7 @@ trait NpsConnection extends StatePensionService {
         metrics.summary(
           statePension.amounts.forecast.weeklyAmount,
           statePension.amounts.current.weeklyAmount,
-          statePension.amounts.cope.weeklyAmount > 0,
+          statePension.contractedOut,
           statePension.forecastScenario,
           statePension.amounts.maximum.weeklyAmount,
           statePension.amounts.forecast.yearsToWork.getOrElse(0),

--- a/test/uk/gov/hmrc/statepension/connectors/CitizenDetailsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/statepension/connectors/CitizenDetailsConnectorSpec.scala
@@ -16,12 +16,16 @@
 
 package uk.gov.hmrc.statepension.connectors
 
+import com.codahale.metrics.Timer
 import org.mockito.Matchers
 import org.mockito.Mockito.when
+import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 import play.api.test.FakeRequest
 import uk.gov.hmrc.play.http._
 import uk.gov.hmrc.statepension.StatePensionUnitSpec
+import uk.gov.hmrc.statepension.domain.nps.APIType
+import uk.gov.hmrc.statepension.services.Metrics
 
 import scala.concurrent.Future
 
@@ -33,9 +37,15 @@ class CitizenDetailsConnectorSpec extends StatePensionUnitSpec with MockitoSugar
   val citizenDetailsConnector = new CitizenDetailsConnector {
     override val serviceUrl: String = "/"
     override val http: HttpGet = mock[HttpGet]
+    override val metrics: Metrics = mock[Metrics]
   }
 
+  val context = mock[Timer.Context]
+  when(context.stop()).thenReturn(0)
+  when(citizenDetailsConnector.metrics.startTimer(Matchers.any())).thenReturn{ context }
+
   "CitizenDetailsConnector" should {
+
     "return OK status when successful" in {
       when(citizenDetailsConnector.http.GET[HttpResponse](Matchers.any())(Matchers.any(), Matchers.any())) thenReturn Future.successful(HttpResponse(200))
       val resultF = citizenDetailsConnector.connectToGetPersonDetails(nino)(hc)

--- a/test/uk/gov/hmrc/statepension/connectors/NpsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/statepension/connectors/NpsConnectorSpec.scala
@@ -129,7 +129,6 @@ class NpsConnectorSpec extends StatePensionUnitSpec with MockitoSugar {
           pensionEntitlement = 161.18,
           startingAmount2016 = 161.18,
           protectedPayment2016 = 5.53,
-          additionalPensionAccruedLastTaxYear = 2.36,
           NpsAmountA2016(
             basicPension = 119.30,
             pre97AP = 17.79,

--- a/test/uk/gov/hmrc/statepension/connectors/NpsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/statepension/connectors/NpsConnectorSpec.scala
@@ -26,6 +26,8 @@ import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.play.http.{HttpGet, HttpResponse}
 import uk.gov.hmrc.statepension.StatePensionUnitSpec
 import uk.gov.hmrc.statepension.domain.nps._
+import uk.gov.hmrc.statepension.helpers.StubMetrics
+import uk.gov.hmrc.statepension.services.Metrics
 
 class NpsConnectorSpec extends StatePensionUnitSpec with MockitoSugar {
 
@@ -34,12 +36,10 @@ class NpsConnectorSpec extends StatePensionUnitSpec with MockitoSugar {
 
   "getSummary" should {
     val connector = new NpsConnector {
-
       override val http = mock[HttpGet]
-
       override def npsBaseUrl: String = "test-url"
-
       override val serviceOriginatorId: (String, String) = ("a_key", "a_value")
+      override val metrics: Metrics = StubMetrics
     }
 
     when(connector.http.GET[HttpResponse](Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(HttpResponse(200, Some(Json.parse(
@@ -214,12 +214,10 @@ class NpsConnectorSpec extends StatePensionUnitSpec with MockitoSugar {
 
   "getLiabilities" should {
     val connector = new NpsConnector {
-
       override val http = mock[HttpGet]
-
       override def npsBaseUrl: String = "test-url"
-
       override val serviceOriginatorId: (String, String) = ("a_key", "a_value")
+      override val metrics: Metrics = StubMetrics
     }
 
     when(connector.http.GET[HttpResponse](Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(HttpResponse(200, Some(Json.parse(
@@ -297,12 +295,10 @@ class NpsConnectorSpec extends StatePensionUnitSpec with MockitoSugar {
 
     "return a failed future with a json validation exception when it cannot parse to an NpsLiabilities" in {
       val connector = new NpsConnector {
-
         override val http = mock[HttpGet]
-
         override def npsBaseUrl: String = "test-url"
-
         override val serviceOriginatorId: (String, String) = ("a_key", "a_value")
+        override val metrics: Metrics = StubMetrics
       }
 
       when(connector.http.GET[HttpResponse](Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(HttpResponse(200, Some(Json.parse(
@@ -363,12 +359,10 @@ class NpsConnectorSpec extends StatePensionUnitSpec with MockitoSugar {
 
   "getNIRecord" should {
     val connector = new NpsConnector {
-
       override val http = mock[HttpGet]
-
       override def npsBaseUrl: String = "test-url"
-
       override val serviceOriginatorId: (String, String) = ("a_key", "a_value")
+      override val metrics: Metrics = StubMetrics
     }
 
     when(connector.http.GET[HttpResponse](Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(HttpResponse(200, Some(Json.parse(
@@ -512,6 +506,8 @@ class NpsConnectorSpec extends StatePensionUnitSpec with MockitoSugar {
         override def npsBaseUrl: String = "test-url"
 
         override val serviceOriginatorId: (String, String) = ("a_key", "a_value")
+
+        override def metrics: Metrics = StubMetrics
       }
 
       when(connector.http.GET[HttpResponse](Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(HttpResponse(200, Some(Json.parse(

--- a/test/uk/gov/hmrc/statepension/domain/nps/NpsSummarySpec.scala
+++ b/test/uk/gov/hmrc/statepension/domain/nps/NpsSummarySpec.scala
@@ -264,7 +264,6 @@ class NpsSummarySpec extends UnitSpec {
         pensionEntitlement = 161.18,
         startingAmount2016 = 161.18,
         protectedPayment2016 = 5.53,
-        additionalPensionAccruedLastTaxYear = 2.36,
         NpsAmountA2016(
           basicPension = 119.3,
           pre97AP = 17.79,
@@ -358,16 +357,6 @@ class NpsSummarySpec extends UnitSpec {
 
         "it is null" in {
           nullAmountJson.as[NpsStatePensionAmounts].protectedPayment2016 shouldBe 0
-        }
-      }
-
-      "parse ap amount correctly" when {
-        "it exists as 11.11" in {
-          amountJson.as[NpsStatePensionAmounts].additionalPensionAccruedLastTaxYear shouldBe 11.11
-        }
-
-        "it is null" in {
-          nullAmountJson.as[NpsStatePensionAmounts].additionalPensionAccruedLastTaxYear shouldBe 0
         }
       }
 

--- a/test/uk/gov/hmrc/statepension/helpers/StubMetrics.scala
+++ b/test/uk/gov/hmrc/statepension/helpers/StubMetrics.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.statepension.helpers
+
+import com.codahale.metrics.Timer
+import com.codahale.metrics.Timer.Context
+import org.scalatest.mock.MockitoSugar
+import uk.gov.hmrc.statepension.domain.Exclusion.Exclusion
+import uk.gov.hmrc.statepension.domain.nps.APIType
+import uk.gov.hmrc.statepension.domain.{MQPScenario, Scenario}
+import uk.gov.hmrc.statepension.services.Metrics
+
+
+object StubMetrics extends Metrics with MockitoSugar {
+  val stubTimerContext: Context = mock[Timer.Context]
+  override def startTimer(api: APIType): Context = mock[Timer.Context]
+  override def incrementFailedCounter(api: APIType): Unit = {}
+  override def summary(forecast: BigDecimal, current: BigDecimal, contractedOut: Boolean, forecastScenario: Scenario, personalMaximum: BigDecimal, yearsToContribute: Int, mqpScenario: Option[MQPScenario]): Unit = {}
+  override def exclusion(exclusion: Exclusion): Unit = {}
+}

--- a/test/uk/gov/hmrc/statepension/services/StatePensionServiceSpec.scala
+++ b/test/uk/gov/hmrc/statepension/services/StatePensionServiceSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.statepension.services
 
 import org.joda.time.LocalDate
-import org.mockito.Matchers
+import org.mockito.{Matchers, Mockito}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mock.MockitoSugar
 import org.scalatestplus.play.OneAppPerSuite
@@ -120,6 +120,7 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
           override lazy val nps: NpsConnector = mock[NpsConnector]
           override lazy val now: LocalDate = new LocalDate(2017, 2, 16)
           override lazy val citizenDetailsService: CitizenDetailsService = mockCitizenDetails
+          override lazy val metrics: Metrics = mock[Metrics]
         }
 
         val regularStatement = NpsSummary(
@@ -166,6 +167,22 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         ))
 
          val statement: Future[StatePension] = service.getStatement(generateNino()).right.get
+
+        "log a summary metric" in {
+          verify(service.metrics, Mockito.atLeastOnce()).summary(
+            Matchers.eq[BigDecimal](161.18),
+            Matchers.eq[BigDecimal](161.18),
+            Matchers.eq(false),
+            Matchers.eq(Scenario.Reached),
+            Matchers.eq[BigDecimal](161.18),
+            Matchers.eq(0),
+            Matchers.eq(None)
+          )
+        }
+
+        "not log an exclusion metric" in {
+          verify(service.metrics, never).exclusion(Matchers.any())
+        }
 
         "return earningsIncludedUpTo of 2016-4-5" in {
           whenReady(statement) { sp =>
@@ -339,12 +356,13 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         override lazy val nps: NpsConnector = mock[NpsConnector]
         override lazy val now: LocalDate = new LocalDate(2017, 2, 16)
         override lazy val citizenDetailsService: CitizenDetailsService = mockCitizenDetails
+        override lazy val metrics: Metrics = mock[Metrics]
       }
 
       val regularStatement = NpsSummary(
         earningsIncludedUpTo = new LocalDate(2016, 4, 5),
         sex = "F",
-        qualifyingYears = 36,
+        qualifyingYears = 20,
         statePensionAgeDate = new LocalDate(2019, 9, 6),
         finalRelevantStartYear = 2018,
         pensionSharingOrderSERPS = false,
@@ -384,7 +402,7 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         NpsNIRecord(payableGaps = 0)
       ))
 
-      lazy val statement: Future[StatePension] = service.getStatement(generateNino()).right.get
+      val statement: Future[StatePension] = service.getStatement(generateNino()).right.get
 
       "the forecast amount" should {
 
@@ -405,6 +423,22 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         }
 
       }
+
+      "log a summary metric" in {
+        verify(service.metrics, times(1)).summary(
+          Matchers.eq[BigDecimal](134.75),
+          Matchers.eq[BigDecimal](121.41),
+          Matchers.eq(false),
+          Matchers.eq(Scenario.ContinueWorkingNonMax),
+          Matchers.eq[BigDecimal](134.75),
+          Matchers.eq(3),
+          Matchers.eq(None)
+        )
+      }
+
+      "not log an exclusion metric" in {
+        verify(service.metrics, never).exclusion(Matchers.any())
+      }
     }
 
     "there is a regular statement (Fill Gaps)" should {
@@ -412,6 +446,7 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         override lazy val nps: NpsConnector = mock[NpsConnector]
         override lazy val now: LocalDate = new LocalDate(2017, 2, 16)
         override lazy val citizenDetailsService: CitizenDetailsService = mockCitizenDetails
+        override lazy val metrics: Metrics = mock[Metrics]
       }
 
       val regularStatement = NpsSummary(
@@ -461,15 +496,15 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
 
       "the personal maximum amount" should {
 
-        "return a weekly forecast amount of 142.71" in {
+        "return a weekly personal max amount of 142.71" in {
           statement.amounts.maximum.weeklyAmount shouldBe 142.71
         }
 
-        "return a monthly forecast amount of 620.53" in {
+        "return a monthly personal max amount of 620.53" in {
           statement.amounts.maximum.monthlyAmount shouldBe 620.53
         }
 
-        "return an annual forecast amount of 7446.40" in {
+        "return an annual personal max amount of 7446.40" in {
           statement.amounts.maximum.annualAmount shouldBe 7446.40
         }
 
@@ -481,6 +516,23 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
           statement.amounts.maximum.yearsToWork shouldBe Some(3)
         }
       }
+
+      "log a summary metric" in {
+        verify(service.metrics, times(1)).summary(
+          Matchers.eq[BigDecimal](134.75),
+          Matchers.eq[BigDecimal](121.41),
+          Matchers.eq(false),
+          Matchers.eq(Scenario.FillGaps),
+          Matchers.eq[BigDecimal](142.71),
+          Matchers.eq(3),
+          Matchers.eq(None)
+        )
+      }
+
+      "not log an exclusion metric" in {
+        verify(service.metrics, never).exclusion(Matchers.any())
+      }
+
     }
 
     "the customer is dead" should {
@@ -489,6 +541,7 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         override lazy val nps: NpsConnector = mock[NpsConnector]
         override lazy val now: LocalDate = new LocalDate(2017, 2, 16)
         override lazy val citizenDetailsService: CitizenDetailsService = mockCitizenDetails
+        override lazy val metrics: Metrics = mock[Metrics]
       }
 
       val summary = NpsSummary(
@@ -536,6 +589,17 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
           exclusion.pensionDate shouldBe new LocalDate(2050, 7, 7)
         }
       }
+
+      "log an exclusion metric" in {
+        verify(service.metrics, times(1)).exclusion(
+          Matchers.eq(Exclusion.Dead)
+        )
+      }
+
+      "not log a summary metric" in {
+        verify(service.metrics, never).summary(Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any())
+      }
+
     }
 
     "the customer is over state pension age" should {
@@ -543,6 +607,7 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         override lazy val nps: NpsConnector = mock[NpsConnector]
         override lazy val now: LocalDate = new LocalDate(2017, 2, 16)
         override lazy val citizenDetailsService: CitizenDetailsService = mockCitizenDetails
+        override lazy val metrics: Metrics = mock[Metrics]
       }
 
       val summary = NpsSummary(
@@ -591,6 +656,17 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
           exclusion.pensionDate shouldBe new LocalDate(2016, 1, 1)
         }
       }
+
+      "log an exclusion metric" in {
+        verify(service.metrics, times(1)).exclusion(
+          Matchers.eq(Exclusion.PostStatePensionAge)
+        )
+      }
+
+      "not log a summary metric" in {
+        verify(service.metrics, never).summary(Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any())
+      }
+
     }
 
     "the customer has married women's reduced rate election" should {
@@ -598,6 +674,7 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         override lazy val nps: NpsConnector = mock[NpsConnector]
         override lazy val now: LocalDate = new LocalDate(2017, 2, 16)
         override lazy val citizenDetailsService: CitizenDetailsService = mockCitizenDetails
+        override lazy val metrics: Metrics = mock[Metrics]
       }
 
       val summary = NpsSummary(
@@ -628,7 +705,7 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
 
       lazy val exclusionF: Future[StatePensionExclusion] = service.getStatement(generateNino()).left.get
 
-      "return post state pension age exclusion" in {
+      "return married women exclusion" in {
         whenReady(exclusionF) { exclusion =>
           exclusion.exclusionReasons shouldBe List(Exclusion.MarriedWomenReducedRateElection)
         }
@@ -645,6 +722,17 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
           exclusion.pensionDate shouldBe new LocalDate(2018, 1, 1)
         }
       }
+
+      "log an exclusion metric" in {
+        verify(service.metrics, times(1)).exclusion(
+          Matchers.eq(Exclusion.MarriedWomenReducedRateElection)
+        )
+      }
+
+      "not log a summary metric" in {
+        verify(service.metrics, never).summary(Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any())
+      }
+
     }
 
     "the customer has male overseas auto credits (abroad exclusion)" should {
@@ -652,6 +740,7 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         override lazy val nps: NpsConnector = mock[NpsConnector]
         override lazy val now: LocalDate = new LocalDate(2017, 2, 16)
         override lazy val citizenDetailsService: CitizenDetailsService = mockCitizenDetails
+        override lazy val metrics: Metrics = mock[Metrics]
       }
 
       val summary = NpsSummary(
@@ -698,6 +787,17 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
           exclusion.pensionDate shouldBe new LocalDate(2018, 1, 1)
         }
       }
+
+      "log an exclusion metric" in {
+        verify(service.metrics, never()).exclusion(
+          Matchers.eq(Exclusion.Abroad)
+        )
+      }
+
+      "not log a summary metric" in {
+        verify(service.metrics, never).summary(Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any())
+      }
+
     }
 
     "the customer has amount dissonance" should {
@@ -705,6 +805,7 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         override lazy val nps: NpsConnector = mock[NpsConnector]
         override lazy val now: LocalDate = new LocalDate(2017, 2, 16)
         override lazy val citizenDetailsService: CitizenDetailsService = mockCitizenDetails
+        override lazy val metrics: Metrics = mock[Metrics]
       }
 
       val summary = NpsSummary(
@@ -753,6 +854,16 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
           exclusion.pensionDate shouldBe new LocalDate(2018, 1, 1)
         }
       }
+
+      "log an exclusion metric" in {
+        verify(service.metrics, times(1)).exclusion(
+          Matchers.eq(Exclusion.AmountDissonance)
+        )
+      }
+
+      "not log a summary metric" in {
+        verify(service.metrics, never).summary(Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any())
+      }
     }
 
     "the customer has contributed national insurance in the isle of man" should {
@@ -760,6 +871,7 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         override lazy val nps: NpsConnector = mock[NpsConnector]
         override lazy val now: LocalDate = new LocalDate(2017, 2, 16)
         override lazy val citizenDetailsService: CitizenDetailsService = mockCitizenDetails
+        override lazy val metrics: Metrics = mock[Metrics]
       }
 
       val summary = NpsSummary(
@@ -802,6 +914,16 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
           exclusion.pensionDate shouldBe new LocalDate(2018, 1, 1)
         }
       }
+
+      "log an exclusion metric" in {
+        verify(service.metrics, times(1)).exclusion(
+          Matchers.eq(Exclusion.IsleOfMan)
+        )
+      }
+
+      "not log a summary metric" in {
+        verify(service.metrics, never).summary(Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any())
+      }
     }
 
     "the customer has a manual correspondence indicator" should {
@@ -809,6 +931,7 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         override lazy val nps: NpsConnector = mock[NpsConnector]
         override lazy val now: LocalDate = new LocalDate(2017, 2, 16)
         override lazy val citizenDetailsService: CitizenDetailsService = mock[CitizenDetailsService]
+        override lazy val metrics: Metrics = mock[Metrics]
       }
 
       val summary = NpsSummary(
@@ -834,7 +957,7 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
 
       lazy val exclusionF: Future[StatePensionExclusion] = service.getStatement(generateNino()).left.get
 
-      "return isle of man exclusion" in {
+      "return mci exclusion" in {
         whenReady(exclusionF) { exclusion =>
           exclusion.exclusionReasons shouldBe List(Exclusion.ManualCorrespondenceIndicator)
         }
@@ -850,6 +973,16 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         whenReady(exclusionF) { exclusion =>
           exclusion.pensionDate shouldBe new LocalDate(2018, 1, 1)
         }
+      }
+
+      "log an exclusion metric" in {
+        verify(service.metrics, times(1)).exclusion(
+          Matchers.eq(Exclusion.ManualCorrespondenceIndicator)
+        )
+      }
+
+      "not log a summary metric" in {
+        verify(service.metrics, never).summary(Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any())
       }
     }
   }

--- a/test/uk/gov/hmrc/statepension/services/StatePensionServiceSpec.scala
+++ b/test/uk/gov/hmrc/statepension/services/StatePensionServiceSpec.scala
@@ -786,7 +786,7 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
       }
 
       "log an exclusion metric" in {
-        verify(service.metrics, never()).exclusion(
+        verify(service.metrics, times(1)).exclusion(
           Matchers.eq(Exclusion.Abroad)
         )
       }

--- a/test/uk/gov/hmrc/statepension/services/StatePensionServiceSpec.scala
+++ b/test/uk/gov/hmrc/statepension/services/StatePensionServiceSpec.scala
@@ -135,7 +135,6 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
             pensionEntitlement = 161.18,
             startingAmount2016 = 161.18,
             protectedPayment2016 = 5.53,
-            additionalPensionAccruedLastTaxYear = 2.36,
             NpsAmountA2016(
               basicPension = 119.3,
               pre97AP = 17.79,
@@ -371,7 +370,6 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
           pensionEntitlement = 121.41,
           startingAmount2016 = 121.41,
           protectedPayment2016 = 5.53,
-          additionalPensionAccruedLastTaxYear = 2.36,
           NpsAmountA2016(
             basicPension = 79.53,
             pre97AP = 17.79,
@@ -461,7 +459,6 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
           pensionEntitlement = 121.41,
           startingAmount2016 = 121.41,
           protectedPayment2016 = 5.53,
-          additionalPensionAccruedLastTaxYear = 2.36,
           NpsAmountA2016(
             basicPension = 79.53,
             pre97AP = 17.79,


### PR DESCRIPTION
This adds timers to the connector classes and metric data events for the two paths.
Decided to try and use a more scala-y way of dealing with enums for the new ones.

I've removed the `ap_amount` field as it's not needed for the new code.

Still to do:
* Audit
* Final hook-up