### PR TITLE
NISP-2447: Manually round nsp_entitlement  to 2dp

### DIFF
--- a/app/uk/gov/hmrc/statepension/domain/nps/NpsSummary.scala
+++ b/app/uk/gov/hmrc/statepension/domain/nps/NpsSummary.scala
@@ -20,6 +20,8 @@ import org.joda.time.{LocalDate, Period}
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
 
+import scala.math.BigDecimal.RoundingMode
+
 
 case class NpsSummary(
                        earningsIncludedUpTo: LocalDate,
@@ -65,7 +67,9 @@ case class NpsStatePensionAmounts(
                                    protectedPayment2016: BigDecimal = 0,
                                    amountA2016: NpsAmountA2016 = NpsAmountA2016(),
                                    amountB2016: NpsAmountB2016 = NpsAmountB2016()
-                                 )
+                                 ) {
+  lazy val pensionEntitlementRounded: BigDecimal = pensionEntitlement.setScale(2, RoundingMode.HALF_UP)
+}
 
 object NpsStatePensionAmounts {
 

--- a/app/uk/gov/hmrc/statepension/services/StatePensionService.scala
+++ b/app/uk/gov/hmrc/statepension/services/StatePensionService.scala
@@ -107,7 +107,7 @@ trait NpsConnection extends StatePensionService {
         val forecast = forecastingService.calculateForecastAmount(
           summary.earningsIncludedUpTo,
           summary.finalRelevantStartYear,
-          summary.amounts.pensionEntitlement,
+          summary.amounts.pensionEntitlementRounded,
           summary.qualifyingYears
         )
 
@@ -128,7 +128,7 @@ trait NpsConnection extends StatePensionService {
           earningsIncludedUpTo = summary.earningsIncludedUpTo,
           amounts = StatePensionAmounts(
             summary.amounts.protectedPayment2016 > 0,
-            StatePensionAmount(None, None, forecastingService.sanitiseCurrentAmount(summary.amounts.pensionEntitlement, summary.qualifyingYears)),
+            StatePensionAmount(None, None, forecastingService.sanitiseCurrentAmount(summary.amounts.pensionEntitlementRounded, summary.qualifyingYears)),
             StatePensionAmount(Some(forecast.yearsToWork), None, forecast.amount),
             StatePensionAmount(Some(personalMaximum.yearsToWork), Some(personalMaximum.gapsToFill), personalMaximum.amount),
             StatePensionAmount(None, None, summary.amounts.amountB2016.rebateDerivedAmount)

--- a/test/uk/gov/hmrc/statepension/domain/nps/NpsSummarySpec.scala
+++ b/test/uk/gov/hmrc/statepension/domain/nps/NpsSummarySpec.scala
@@ -593,4 +593,13 @@ class NpsSummarySpec extends UnitSpec {
       }
     }
   }
+
+  "pensionEntitlementRounded" should {
+    "return 5 up" in {
+      NpsStatePensionAmounts(pensionEntitlement = 123.4554).pensionEntitlementRounded shouldBe 123.46
+    }
+    "return 4 down" in {
+      NpsStatePensionAmounts(pensionEntitlement = 123.4547).pensionEntitlementRounded shouldBe 123.45
+    }
+  }
 }

--- a/test/uk/gov/hmrc/statepension/services/StatePensionServiceSpec.scala
+++ b/test/uk/gov/hmrc/statepension/services/StatePensionServiceSpec.scala
@@ -471,7 +471,7 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         pensionSharingOrderSERPS = false,
         dateOfBirth = new LocalDate(1954, 3, 9),
         amounts = NpsStatePensionAmounts(
-          pensionEntitlement = 121.41,
+          pensionEntitlement = 121.4123,
           startingAmount2016 = 121.41,
           protectedPayment2016 = 5.53,
           NpsAmountA2016(


### PR DESCRIPTION
This PR will ensure the service can remain unshuttered on the 10th April 2017 while work is being carried out on the HODs.