### PR TITLE
DDCNLS-1009: Switch qualifyingYears source from sp_summary to nirecord

### DIFF
--- a/app/uk/gov/hmrc/statepension/domain/nps/NpsSummary.scala
+++ b/app/uk/gov/hmrc/statepension/domain/nps/NpsSummary.scala
@@ -26,7 +26,6 @@ import scala.math.BigDecimal.RoundingMode
 case class NpsSummary(
                        earningsIncludedUpTo: LocalDate,
                        sex: String,
-                       qualifyingYears: Int,
                        statePensionAgeDate: LocalDate,
                        finalRelevantStartYear: Int,
                        pensionSharingOrderSERPS: Boolean,
@@ -48,7 +47,6 @@ object NpsSummary {
   implicit val reads: Reads[NpsSummary] = (
     (JsPath \ "earnings_included_upto").read[LocalDate] and
       (JsPath \ "sex").read[String] and
-      (JsPath \ "nsp_qualifying_years").read[Int] and
       (JsPath \ "spa_date").read[LocalDate] and
       (JsPath \ "final_relevant_year").read[Int] and
       readBooleanFromInt(JsPath \ "pension_share_order_serps") and

--- a/test/uk/gov/hmrc/statepension/connectors/NpsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/statepension/connectors/NpsConnectorSpec.scala
@@ -37,7 +37,9 @@ class NpsConnectorSpec extends StatePensionUnitSpec with MockitoSugar {
   "getSummary" should {
     val connector = new NpsConnector {
       override val http = mock[HttpGet]
+
       override def npsBaseUrl: String = "test-url"
+
       override val serviceOriginatorId: (String, String) = ("a_key", "a_value")
       override val metrics: Metrics = StubMetrics
     }
@@ -117,7 +119,6 @@ class NpsConnectorSpec extends StatePensionUnitSpec with MockitoSugar {
       summary shouldBe NpsSummary(
         new LocalDate(2016, 4, 5),
         "M",
-        qualifyingYears = 36,
         statePensionAgeDate = new LocalDate(2019, 9, 6),
         finalRelevantStartYear = 2018,
         pensionSharingOrderSERPS = true,
@@ -214,7 +215,9 @@ class NpsConnectorSpec extends StatePensionUnitSpec with MockitoSugar {
   "getLiabilities" should {
     val connector = new NpsConnector {
       override val http = mock[HttpGet]
+
       override def npsBaseUrl: String = "test-url"
+
       override val serviceOriginatorId: (String, String) = ("a_key", "a_value")
       override val metrics: Metrics = StubMetrics
     }
@@ -295,7 +298,9 @@ class NpsConnectorSpec extends StatePensionUnitSpec with MockitoSugar {
     "return a failed future with a json validation exception when it cannot parse to an NpsLiabilities" in {
       val connector = new NpsConnector {
         override val http = mock[HttpGet]
+
         override def npsBaseUrl: String = "test-url"
+
         override val serviceOriginatorId: (String, String) = ("a_key", "a_value")
         override val metrics: Metrics = StubMetrics
       }
@@ -359,127 +364,129 @@ class NpsConnectorSpec extends StatePensionUnitSpec with MockitoSugar {
   "getNIRecord" should {
     val connector = new NpsConnector {
       override val http = mock[HttpGet]
+
       override def npsBaseUrl: String = "test-url"
+
       override val serviceOriginatorId: (String, String) = ("a_key", "a_value")
       override val metrics: Metrics = StubMetrics
     }
 
     when(connector.http.GET[HttpResponse](Matchers.any())(Matchers.any(), Matchers.any())).thenReturn(HttpResponse(200, Some(Json.parse(
       s"""
-        |{
-        |  "years_to_fry": 3,
-        |  "non_qualifying_years": 10,
-        |  "date_of_entry": "1969-08-01",
-        |  "npsLniemply": [],
-        |  "pre_75_cc_count": 250,
-        |  "number_of_qualifying_years": 36,
-        |  "npsErrlist": {
-        |    "count": 0,
-        |    "mgt_check": 0,
-        |    "commit_status": 2,
-        |    "npsErritem": [],
-        |    "bfm_return_code": 0,
-        |    "data_not_found": 0
-        |  },
-        |  "non_qualifying_years_payable": 5,
-        |  "npsLnitaxyr": [
-        |    {
-        |      "class_three_payable_by_penalty": null,
-        |      "class_two_outstanding_weeks": null,
-        |      "class_two_payable": null,
-        |      "qualifying": 1,
-        |      "under_investigation_flag": 0,
-        |      "class_two_payable_by": null,
-        |      "co_class_one_paid": null,
-        |      "class_two_payable_by_penalty": null,
-        |      "co_primary_paid_earnings": null,
-        |      "payable": 0,
-        |      "rattd_tax_year": 1975,
-        |      "ni_earnings": null,
-        |      "amount_needed": null,
-        |      "primary_paid_earnings": "1285.4500",
-        |      "class_three_payable": null,
-        |      "ni_earnings_employed": "70.6700",
-        |      "npsLothcred": [
-        |        {
-        |          "credit_source_type": 0,
-        |          "cc_type": 23,
-        |          "no_of_credits_and_conts": 20
-        |        },
-        |        {
-        |          "credit_source_type": 24,
-        |          "cc_type": 23,
-        |          "no_of_credits_and_conts": 6
-        |        }
-        |      ],
-        |      "ni_earnings_self_employed": null,
-        |      "class_three_payable_by": null,
-        |      "ni_earnings_voluntary": null
-        |    },
-        |    {
-        |      "class_three_payable_by_penalty": null,
-        |      "class_two_outstanding_weeks": null,
-        |      "class_two_payable": null,
-        |      "qualifying": 1,
-        |      "under_investigation_flag": 0,
-        |      "class_two_payable_by": null,
-        |      "co_class_one_paid": null,
-        |      "class_two_payable_by_penalty": null,
-        |      "co_primary_paid_earnings": null,
-        |      "payable": 0,
-        |      "rattd_tax_year": 1976,
-        |      "ni_earnings": null,
-        |      "amount_needed": null,
-        |      "primary_paid_earnings": "932.1700",
-        |      "class_three_payable": null,
-        |      "ni_earnings_employed": "53.5000",
-        |      "npsLothcred": [
-        |        {
-        |          "credit_source_type": 0,
-        |          "cc_type": 23,
-        |          "no_of_credits_and_conts": 4
-        |        },
-        |        {
-        |          "credit_source_type": 24,
-        |          "cc_type": 23,
-        |          "no_of_credits_and_conts": 30
-        |        }
-        |      ],
-        |      "ni_earnings_self_employed": null,
-        |      "class_three_payable_by": null,
-        |      "ni_earnings_voluntary": null
-        |    },
-        |    {
-        |      "class_three_payable_by_penalty": null,
-        |      "class_two_outstanding_weeks": null,
-        |      "class_two_payable": null,
-        |      "qualifying": 1,
-        |      "under_investigation_flag": 0,
-        |      "class_two_payable_by": null,
-        |      "co_class_one_paid": null,
-        |      "class_two_payable_by_penalty": null,
-        |      "co_primary_paid_earnings": null,
-        |      "payable": 0,
-        |      "rattd_tax_year": 1977,
-        |      "ni_earnings": null,
-        |      "amount_needed": null,
-        |      "primary_paid_earnings": "1433.0400",
-        |      "class_three_payable": null,
-        |      "ni_earnings_employed": "82.1300",
-        |      "npsLothcred": [
-        |        {
-        |          "credit_source_type": 24,
-        |          "cc_type": 23,
-        |          "no_of_credits_and_conts": 28
-        |        }
-        |      ],
-        |      "ni_earnings_self_employed": null,
-        |      "class_three_payable_by": null,
-        |      "ni_earnings_voluntary": null
-        |    }
-        |  ],
-        |  "nino": "$nino"
-        |}""".stripMargin))))
+         |{
+         |  "years_to_fry": 3,
+         |  "non_qualifying_years": 10,
+         |  "date_of_entry": "1969-08-01",
+         |  "npsLniemply": [],
+         |  "pre_75_cc_count": 250,
+         |  "number_of_qualifying_years": 36,
+         |  "npsErrlist": {
+         |    "count": 0,
+         |    "mgt_check": 0,
+         |    "commit_status": 2,
+         |    "npsErritem": [],
+         |    "bfm_return_code": 0,
+         |    "data_not_found": 0
+         |  },
+         |  "non_qualifying_years_payable": 5,
+         |  "npsLnitaxyr": [
+         |    {
+         |      "class_three_payable_by_penalty": null,
+         |      "class_two_outstanding_weeks": null,
+         |      "class_two_payable": null,
+         |      "qualifying": 1,
+         |      "under_investigation_flag": 0,
+         |      "class_two_payable_by": null,
+         |      "co_class_one_paid": null,
+         |      "class_two_payable_by_penalty": null,
+         |      "co_primary_paid_earnings": null,
+         |      "payable": 0,
+         |      "rattd_tax_year": 1975,
+         |      "ni_earnings": null,
+         |      "amount_needed": null,
+         |      "primary_paid_earnings": "1285.4500",
+         |      "class_three_payable": null,
+         |      "ni_earnings_employed": "70.6700",
+         |      "npsLothcred": [
+         |        {
+         |          "credit_source_type": 0,
+         |          "cc_type": 23,
+         |          "no_of_credits_and_conts": 20
+         |        },
+         |        {
+         |          "credit_source_type": 24,
+         |          "cc_type": 23,
+         |          "no_of_credits_and_conts": 6
+         |        }
+         |      ],
+         |      "ni_earnings_self_employed": null,
+         |      "class_three_payable_by": null,
+         |      "ni_earnings_voluntary": null
+         |    },
+         |    {
+         |      "class_three_payable_by_penalty": null,
+         |      "class_two_outstanding_weeks": null,
+         |      "class_two_payable": null,
+         |      "qualifying": 1,
+         |      "under_investigation_flag": 0,
+         |      "class_two_payable_by": null,
+         |      "co_class_one_paid": null,
+         |      "class_two_payable_by_penalty": null,
+         |      "co_primary_paid_earnings": null,
+         |      "payable": 0,
+         |      "rattd_tax_year": 1976,
+         |      "ni_earnings": null,
+         |      "amount_needed": null,
+         |      "primary_paid_earnings": "932.1700",
+         |      "class_three_payable": null,
+         |      "ni_earnings_employed": "53.5000",
+         |      "npsLothcred": [
+         |        {
+         |          "credit_source_type": 0,
+         |          "cc_type": 23,
+         |          "no_of_credits_and_conts": 4
+         |        },
+         |        {
+         |          "credit_source_type": 24,
+         |          "cc_type": 23,
+         |          "no_of_credits_and_conts": 30
+         |        }
+         |      ],
+         |      "ni_earnings_self_employed": null,
+         |      "class_three_payable_by": null,
+         |      "ni_earnings_voluntary": null
+         |    },
+         |    {
+         |      "class_three_payable_by_penalty": null,
+         |      "class_two_outstanding_weeks": null,
+         |      "class_two_payable": null,
+         |      "qualifying": 1,
+         |      "under_investigation_flag": 0,
+         |      "class_two_payable_by": null,
+         |      "co_class_one_paid": null,
+         |      "class_two_payable_by_penalty": null,
+         |      "co_primary_paid_earnings": null,
+         |      "payable": 0,
+         |      "rattd_tax_year": 1977,
+         |      "ni_earnings": null,
+         |      "amount_needed": null,
+         |      "primary_paid_earnings": "1433.0400",
+         |      "class_three_payable": null,
+         |      "ni_earnings_employed": "82.1300",
+         |      "npsLothcred": [
+         |        {
+         |          "credit_source_type": 24,
+         |          "cc_type": 23,
+         |          "no_of_credits_and_conts": 28
+         |        }
+         |      ],
+         |      "ni_earnings_self_employed": null,
+         |      "class_three_payable_by": null,
+         |      "ni_earnings_voluntary": null
+         |    }
+         |  ],
+         |  "nino": "$nino"
+         |}""".stripMargin))))
 
     connector.getNIRecord(nino)
 
@@ -494,11 +501,13 @@ class NpsConnectorSpec extends StatePensionUnitSpec with MockitoSugar {
 
     "parse the json and return a Future[NpsNIRecord]" in {
       val summary = await(connector.getNIRecord(nino))
-      summary shouldBe NpsNIRecord(List(
-        NpsNITaxYear(1975, qualifying = true, underInvestigation = false, payableFlag = false),
-        NpsNITaxYear(1976, qualifying = true, underInvestigation = false, payableFlag = false),
-        NpsNITaxYear(1977, qualifying = true, underInvestigation = false, payableFlag = false)
-      ))
+      summary shouldBe NpsNIRecord(
+        qualifyingYears = 36,
+        List(
+          NpsNITaxYear(1975, qualifying = true, underInvestigation = false, payableFlag = false),
+          NpsNITaxYear(1976, qualifying = true, underInvestigation = false, payableFlag = false),
+          NpsNITaxYear(1977, qualifying = true, underInvestigation = false, payableFlag = false)
+        ))
     }
 
     "return a failed future with a json validation exception when it cannot parse to an NpsNIRecord" in {

--- a/test/uk/gov/hmrc/statepension/domain/nps/NpsNIRecordSpec.scala
+++ b/test/uk/gov/hmrc/statepension/domain/nps/NpsNIRecordSpec.scala
@@ -1255,6 +1255,10 @@ class NpsNIRecordSpec extends StatePensionUnitSpec {
       )
     }
 
+    "parse qualifying years correctly (from json)" in {
+      recordJson.qualifyingYears shouldBe 36
+    }
+
     "parse payable gaps correctly (count, not read the non_qualifying_years_payable field)" in {
       recordJson.payableGapsPre2016 shouldBe 4
       recordJson.payableGapsPost2016 shouldBe 2
@@ -1264,20 +1268,25 @@ class NpsNIRecordSpec extends StatePensionUnitSpec {
       recordJson.qualifyingYearsPost2016 shouldBe 1
     }
 
+    "parse qualifying years pre 2016 correct (take post away from total)" in {
+      recordJson.qualifyingYearsPre2016 shouldBe 35
+    }
+
     "purge" should {
       "return an nirecord with no tax years after 2014 when the FRY 2014" in {
-        val niRecord = NpsNIRecord(List(
+        val niRecord = NpsNIRecord(qualifyingYears = 6, List(
           NpsNITaxYear(2010, qualifying = true, underInvestigation = false, payableFlag = false),
           NpsNITaxYear(2011, qualifying = true, underInvestigation = false, payableFlag = false),
           NpsNITaxYear(2012, qualifying = true, underInvestigation = false, payableFlag = false),
           NpsNITaxYear(2013, qualifying = true, underInvestigation = false, payableFlag = false),
           NpsNITaxYear(2014, qualifying = true, underInvestigation = false, payableFlag = false),
           NpsNITaxYear(2015, qualifying = false, underInvestigation = false, payableFlag = true),
-          NpsNITaxYear(2016, qualifying = false, underInvestigation = false, payableFlag = true)
+          NpsNITaxYear(2016, qualifying = true, underInvestigation = false, payableFlag = false)
         ))
 
         val purged = niRecord.purge(finalRelevantStartYear = 2014)
 
+        purged.qualifyingYears shouldBe 5
         purged.payableGapsPre2016 shouldBe 0
         purged.qualifyingYearsPost2016 shouldBe 0
         purged.taxYears shouldBe List(
@@ -1290,7 +1299,7 @@ class NpsNIRecordSpec extends StatePensionUnitSpec {
       }
 
       "return an nirecord with no tax years after 2015 when the FRY 2015" in {
-        val niRecord = NpsNIRecord(List(
+        val niRecord = NpsNIRecord(qualifyingYears = 3, List(
           NpsNITaxYear(2010, qualifying = true, underInvestigation = false, payableFlag = false),
           NpsNITaxYear(2011, qualifying = false, underInvestigation = false, payableFlag = false),
           NpsNITaxYear(2012, qualifying = false, underInvestigation = false, payableFlag = true),
@@ -1302,6 +1311,7 @@ class NpsNIRecordSpec extends StatePensionUnitSpec {
 
         val purged = niRecord.purge(finalRelevantStartYear = 2015)
 
+        purged.qualifyingYears shouldBe 3
         purged.payableGapsPre2016 shouldBe 2
         purged.qualifyingYearsPost2016 shouldBe 0
         purged.taxYears shouldBe List(

--- a/test/uk/gov/hmrc/statepension/domain/nps/NpsSummarySpec.scala
+++ b/test/uk/gov/hmrc/statepension/domain/nps/NpsSummarySpec.scala
@@ -82,14 +82,13 @@ class NpsSummarySpec extends UnitSpec {
     """.stripMargin)
 
   "NpsSummary" should {
+
     "parse earnings included up to correctly" in {
       summaryJson.as[NpsSummary].earningsIncludedUpTo shouldBe new LocalDate(2015, 4, 5)
     }
+
     "parse sex correctly" in {
       summaryJson.as[NpsSummary].sex shouldBe "M"
-    }
-    "parse qualifying_years correctly" in {
-      summaryJson.as[NpsSummary].qualifyingYears shouldBe 36
     }
 
     "parse state pension age date correctly" when {
@@ -524,7 +523,6 @@ class NpsSummarySpec extends UnitSpec {
     def summaryWithFinalRelevantStartYear(finalRelevantStartYear: Int) = NpsSummary(
       earningsIncludedUpTo = new LocalDate(2016, 4, 5),
       sex = "F",
-      qualifyingYears = 20,
       statePensionAgeDate = new LocalDate(2020, 6, 9),
       finalRelevantStartYear = finalRelevantStartYear,
       pensionSharingOrderSERPS = false,
@@ -562,7 +560,6 @@ class NpsSummarySpec extends UnitSpec {
     def summaryWithDOBandSPA(dateOfBirth: LocalDate, statePensionAgeDate: LocalDate) = NpsSummary(
       earningsIncludedUpTo = new LocalDate(2016, 4, 5),
       sex = "F",
-      qualifyingYears = 20,
       statePensionAgeDate = statePensionAgeDate,
       finalRelevantStartYear = 2020,
       pensionSharingOrderSERPS = false,

--- a/test/uk/gov/hmrc/statepension/services/StatePensionServiceSpec.scala
+++ b/test/uk/gov/hmrc/statepension/services/StatePensionServiceSpec.scala
@@ -135,7 +135,6 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         val regularStatement = NpsSummary(
           earningsIncludedUpTo = new LocalDate(2016, 4, 5),
           sex = "F",
-          qualifyingYears = 36,
           statePensionAgeDate = new LocalDate(2019, 9, 6),
           finalRelevantStartYear = 2018,
           pensionSharingOrderSERPS = false,
@@ -171,7 +170,7 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         ))
 
         when(service.nps.getNIRecord(Matchers.any())(Matchers.any())).thenReturn(Future.successful(
-          NpsNIRecord(List())
+          NpsNIRecord(qualifyingYears = 36, List())
         ))
 
         val statement: Future[StatePension] = service.getStatement(generateNino()).right.get
@@ -373,7 +372,6 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
       val regularStatement = NpsSummary(
         earningsIncludedUpTo = new LocalDate(2016, 4, 5),
         sex = "F",
-        qualifyingYears = 20,
         statePensionAgeDate = new LocalDate(2019, 9, 6),
         finalRelevantStartYear = 2018,
         pensionSharingOrderSERPS = false,
@@ -409,7 +407,7 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
       ))
 
       when(service.nps.getNIRecord(Matchers.any())(Matchers.any())).thenReturn(Future.successful(
-        NpsNIRecord(List())
+        NpsNIRecord(qualifyingYears = 20, List())
       ))
 
       val statement: Future[StatePension] = service.getStatement(generateNino()).right.get
@@ -465,7 +463,6 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
       val regularStatement = NpsSummary(
         earningsIncludedUpTo = new LocalDate(2016, 4, 5),
         sex = "F",
-        qualifyingYears = 20,
         statePensionAgeDate = new LocalDate(2019, 9, 6),
         finalRelevantStartYear = 2018,
         pensionSharingOrderSERPS = false,
@@ -501,7 +498,7 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
       ))
 
       when(service.nps.getNIRecord(Matchers.any())(Matchers.any())).thenReturn(Future.successful(
-        NpsNIRecord(List(NpsNITaxYear(2000, false, false, true), NpsNITaxYear(2001, false, false, true)))
+        NpsNIRecord(qualifyingYears = 20, List(NpsNITaxYear(2000, false, false, true), NpsNITaxYear(2001, false, false, true)))
       ))
 
       lazy val statement: Future[StatePension] = service.getStatement(generateNino()).right.get
@@ -561,7 +558,6 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
       val regularStatement = NpsSummary(
         earningsIncludedUpTo = new LocalDate(2016, 4, 5),
         sex = "F",
-        qualifyingYears = 9,
         statePensionAgeDate = new LocalDate(2019, 9, 6),
         finalRelevantStartYear = 2018,
         pensionSharingOrderSERPS = false,
@@ -597,7 +593,7 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
       ))
 
       when(service.nps.getNIRecord(Matchers.any())(Matchers.any())).thenReturn(Future.successful(
-        NpsNIRecord(List())
+        NpsNIRecord(qualifyingYears = 9, List())
       ))
 
       "return 0 for the current amount" in {
@@ -621,7 +617,6 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
       val summary = NpsSummary(
         earningsIncludedUpTo = new LocalDate(2016, 4, 5),
         sex = "F",
-        qualifyingYears = 35,
         statePensionAgeDate = new LocalDate(2050, 7, 7),
         finalRelevantStartYear = 2049,
         pensionSharingOrderSERPS = false,
@@ -633,7 +628,7 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
       )
 
       when(service.nps.getNIRecord(Matchers.any())(Matchers.any())).thenReturn(Future.successful(
-        NpsNIRecord(List(NpsNITaxYear(2000, false, false, true), NpsNITaxYear(2001, false, false, true)))
+        NpsNIRecord(qualifyingYears = 35, List(NpsNITaxYear(2000, false, false, true), NpsNITaxYear(2001, false, false, true)))
       ))
 
       when(service.nps.getSummary(Matchers.any())(Matchers.any())).thenReturn(Future.successful(
@@ -690,7 +685,6 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
       val summary = NpsSummary(
         earningsIncludedUpTo = new LocalDate(1954, 4, 5),
         sex = "F",
-        qualifyingYears = 35,
         statePensionAgeDate = new LocalDate(2016, 1, 1),
         finalRelevantStartYear = 2049,
         pensionSharingOrderSERPS = false,
@@ -711,7 +705,7 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
       ))
 
       when(service.nps.getNIRecord(Matchers.any())(Matchers.any())).thenReturn(Future.successful(
-        NpsNIRecord(List(NpsNITaxYear(2000, false, false, true), NpsNITaxYear(2001, false, false, true)))
+        NpsNIRecord(qualifyingYears = 35, List(NpsNITaxYear(2000, false, false, true), NpsNITaxYear(2001, false, false, true)))
       ))
 
       lazy val exclusionF: Future[StatePensionExclusion] = service.getStatement(generateNino()).left.get
@@ -760,7 +754,6 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
       val summary = NpsSummary(
         earningsIncludedUpTo = new LocalDate(2016, 4, 5),
         sex = "F",
-        qualifyingYears = 35,
         statePensionAgeDate = new LocalDate(2018, 1, 1),
         finalRelevantStartYear = 2049,
         pensionSharingOrderSERPS = false,
@@ -780,7 +773,7 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
       ))
 
       when(service.nps.getNIRecord(Matchers.any())(Matchers.any())).thenReturn(Future.successful(
-        NpsNIRecord(List(NpsNITaxYear(2000, false, false, true), NpsNITaxYear(2001, false, false, true)))
+        NpsNIRecord(qualifyingYears = 35, List(NpsNITaxYear(2000, false, false, true), NpsNITaxYear(2001, false, false, true)))
       ))
 
       lazy val exclusionF: Future[StatePensionExclusion] = service.getStatement(generateNino()).left.get
@@ -829,7 +822,6 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
       val summary = NpsSummary(
         earningsIncludedUpTo = new LocalDate(2016, 4, 5),
         sex = "M",
-        qualifyingYears = 35,
         statePensionAgeDate = new LocalDate(2018, 1, 1),
         finalRelevantStartYear = 2049,
         pensionSharingOrderSERPS = false,
@@ -848,7 +840,7 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         List()
       ))
       when(service.nps.getNIRecord(Matchers.any())(Matchers.any())).thenReturn(Future.successful(
-        NpsNIRecord(List(NpsNITaxYear(2000, false, false, true), NpsNITaxYear(2001, false, false, true)))
+        NpsNIRecord(qualifyingYears = 35, List(NpsNITaxYear(2000, false, false, true), NpsNITaxYear(2001, false, false, true)))
       ))
 
       lazy val exclusionF: Future[StatePensionExclusion] = service.getStatement(generateNino()).left.get
@@ -897,7 +889,6 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
       val summary = NpsSummary(
         earningsIncludedUpTo = new LocalDate(2016, 4, 5),
         sex = "M",
-        qualifyingYears = 35,
         statePensionAgeDate = new LocalDate(2018, 1, 1),
         finalRelevantStartYear = 2049,
         pensionSharingOrderSERPS = false,
@@ -918,7 +909,7 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         List()
       ))
       when(service.nps.getNIRecord(Matchers.any())(Matchers.any())).thenReturn(Future.successful(
-        NpsNIRecord(List(NpsNITaxYear(2000, false, false, true), NpsNITaxYear(2001, false, false, true)))
+        NpsNIRecord(qualifyingYears = 35, List(NpsNITaxYear(2000, false, false, true), NpsNITaxYear(2001, false, false, true)))
       ))
 
       lazy val exclusionF: Future[StatePensionExclusion] = service.getStatement(generateNino()).left.get
@@ -966,7 +957,6 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
       val summary = NpsSummary(
         earningsIncludedUpTo = new LocalDate(2016, 4, 5),
         sex = "M",
-        qualifyingYears = 35,
         statePensionAgeDate = new LocalDate(2018, 1, 1),
         finalRelevantStartYear = 2049,
         pensionSharingOrderSERPS = false,
@@ -980,7 +970,7 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         List(NpsLiability(5))
       ))
       when(service.nps.getNIRecord(Matchers.any())(Matchers.any())).thenReturn(Future.successful(
-        NpsNIRecord(List(NpsNITaxYear(2000, false, false, true), NpsNITaxYear(2001, false, false, true)))
+        NpsNIRecord(qualifyingYears = 35, List(NpsNITaxYear(2000, false, false, true), NpsNITaxYear(2001, false, false, true)))
       ))
 
 
@@ -1029,7 +1019,6 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
       val summary = NpsSummary(
         earningsIncludedUpTo = new LocalDate(2016, 4, 5),
         sex = "M",
-        qualifyingYears = 35,
         statePensionAgeDate = new LocalDate(2018, 1, 1),
         finalRelevantStartYear = 2049,
         pensionSharingOrderSERPS = false,
@@ -1044,7 +1033,7 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
       ))
       when(service.citizenDetailsService.checkManualCorrespondenceIndicator(Matchers.any())(Matchers.any())).thenReturn(Future.successful(true))
       when(service.nps.getNIRecord(Matchers.any())(Matchers.any())).thenReturn(Future.successful(
-        NpsNIRecord(List(NpsNITaxYear(2000, false, false, true), NpsNITaxYear(2001, false, false, true)))
+        NpsNIRecord(qualifyingYears = 35, List(NpsNITaxYear(2000, false, false, true), NpsNITaxYear(2001, false, false, true)))
       ))
 
       lazy val exclusionF: Future[StatePensionExclusion] = service.getStatement(generateNino()).left.get


### PR DESCRIPTION
This is a workaround as our supplier has confirmed that the
qualifyingYears from the sp_summary API is no longer correct. The
workaround is to parse the qualifyingYears from the nirecord API
instead.