### PR TITLE
CYSPA-74: Add flag to exclusion object

### DIFF
--- a/app/uk/gov/hmrc/statepension/controllers/StatePensionController.scala
+++ b/app/uk/gov/hmrc/statepension/controllers/StatePensionController.scala
@@ -37,17 +37,17 @@ trait StatePensionController extends BaseController with HeaderValidator with Er
 
         case Left(exclusion) if exclusion.exclusionReasons.contains(Exclusion.Dead) =>
           customAuditConnector.sendEvent(StatePensionExclusion(nino, List(Exclusion.Dead),
-            exclusion.pensionAge, exclusion.pensionDate))
+            exclusion.pensionAge, exclusion.pensionDate, exclusion.statePensionAgeUnderConsideration))
           Forbidden(Json.toJson(ErrorResponses.ExclusionDead))
 
         case Left(exclusion) if exclusion.exclusionReasons.contains(Exclusion.ManualCorrespondenceIndicator) =>
           customAuditConnector.sendEvent(StatePensionExclusion(nino, List(Exclusion.ManualCorrespondenceIndicator),
-            exclusion.pensionAge, exclusion.pensionDate))
+            exclusion.pensionAge, exclusion.pensionDate, exclusion.statePensionAgeUnderConsideration))
           Forbidden(Json.toJson(ErrorResponses.ExclusionManualCorrespondence))
 
         case Left(exclusion) =>
           customAuditConnector.sendEvent(StatePensionExclusion(nino, exclusion.exclusionReasons,
-            exclusion.pensionAge, exclusion.pensionDate))
+            exclusion.pensionAge, exclusion.pensionDate, exclusion.statePensionAgeUnderConsideration))
           Ok(halResourceSelfLink(Json.toJson(exclusion), statePensionHref(nino)))
 
         case Right(statePension) =>

--- a/app/uk/gov/hmrc/statepension/domain/StatePensionExclusion.scala
+++ b/app/uk/gov/hmrc/statepension/domain/StatePensionExclusion.scala
@@ -35,7 +35,8 @@ object Exclusion extends Enumeration {
 
 case class StatePensionExclusion(exclusionReasons: List[Exclusion.Exclusion],
                                  pensionAge: Int,
-                                 pensionDate: LocalDate)
+                                 pensionDate: LocalDate,
+                                 statePensionAgeUnderConsideration: Boolean)
 
 object StatePensionExclusion {
   implicit val formats = Json.format[StatePensionExclusion]

--- a/app/uk/gov/hmrc/statepension/events/StatePensionExclusion.scala
+++ b/app/uk/gov/hmrc/statepension/events/StatePensionExclusion.scala
@@ -25,15 +25,17 @@ import uk.gov.hmrc.http.HeaderCarrier
 
 object StatePensionExclusion{
   def apply(nino: Nino, exclusionReasons: List[Exclusion.Exclusion], pensionAge: Int,
-            pensionDate: LocalDate)(implicit hc: HeaderCarrier): StatePensionExclusion =
-    new StatePensionExclusion(nino, exclusionReasons, pensionAge, pensionDate)
+            pensionDate: LocalDate, statePensionAgeUnderConsideration: Boolean)(implicit hc: HeaderCarrier): StatePensionExclusion =
+    new StatePensionExclusion(nino, exclusionReasons, pensionAge, pensionDate, statePensionAgeUnderConsideration)
 }
 
-class StatePensionExclusion(nino: Nino, exclusionReasons: List[Exclusion.Exclusion], pensionAge: Int, pensionDate: LocalDate) (implicit hc: HeaderCarrier)
+class StatePensionExclusion(nino: Nino, exclusionReasons: List[Exclusion.Exclusion], pensionAge: Int, pensionDate: LocalDate,
+                            statePensionAgeUnderConsideration: Boolean) (implicit hc: HeaderCarrier)
   extends BusinessEvent("StatePensionExclusion", nino,
     Map(
       "reasons" -> exclusionReasons.map(_.toString).mkString(","),
       "pensionAge" -> pensionAge.toString,
-      "pensionDate" -> pensionDate.toString
+      "pensionDate" -> pensionDate.toString,
+      "statePensionAgeUnderConsideration" -> statePensionAgeUnderConsideration.toString
     )
   )

--- a/app/uk/gov/hmrc/statepension/services/StatePensionService.scala
+++ b/app/uk/gov/hmrc/statepension/services/StatePensionService.scala
@@ -96,7 +96,9 @@ trait NpsConnection extends StatePensionService {
         Left(StatePensionExclusion(
           exclusionReasons = exclusions,
           pensionAge = summary.statePensionAge,
-          pensionDate = summary.statePensionAgeDate
+          pensionDate = summary.statePensionAgeDate,
+          statePensionAgeUnderConsideration = if (exclusions.contains(Exclusion.AmountDissonance) || exclusions.contains(Exclusion.IsleOfMan))
+            checkStatePensionAgeUnderConsideration(summary.dateOfBirth) else false
         ))
       } else {
 

--- a/conf/resources/sandbox/EZ.json
+++ b/conf/resources/sandbox/EZ.json
@@ -3,5 +3,6 @@
     "Dead"
   ],
   "pensionAge": 66,
-  "pensionDate": "2021-05-16"
+  "pensionDate": "2021-05-16",
+  "statePensionAgeUnderConsideration": false
 }

--- a/conf/resources/sandbox/PG.json
+++ b/conf/resources/sandbox/PG.json
@@ -3,5 +3,6 @@
     "ManualCorrespondenceIndicator"
   ],
   "pensionAge": 66,
-  "pensionDate": "2021-05-16"
+  "pensionDate": "2021-05-16",
+  "statePensionAgeUnderConsideration": false
 }

--- a/conf/resources/sandbox/PS.json
+++ b/conf/resources/sandbox/PS.json
@@ -3,5 +3,6 @@
     "PostStatePensionAge"
   ],
   "pensionAge": 66,
-  "pensionDate": "2021-05-16"
+  "pensionDate": "2021-05-16",
+  "statePensionAgeUnderConsideration": false
 }

--- a/public/api/conf/1.0/examples/ni-example-3.json
+++ b/public/api/conf/1.0/examples/ni-example-3.json
@@ -4,6 +4,7 @@
   ],
   "pensionAge": 66,
   "pensionDate": "2021-05-16",
+  "statePensionAgeUnderConsideration": false,
   "_links" : {
     "self": {
       "href": "/state-pension/ni/QQ123456A"

--- a/public/api/conf/1.0/schemas/exclusion-response.json
+++ b/public/api/conf/1.0/schemas/exclusion-response.json
@@ -17,6 +17,11 @@
       "type": "string",
       "description": "The date the customer can claim State Pension",
       "example": "2021-05-16"
+    },
+    "statePensionAgeUnderConsideration": {
+      "type": "boolean",
+      "description": "Whether the customer has a date of birth between 6 April 1970 and 5 April 1978.  These customers may have a change to their State Pension age due to an ongoing government consultation.",
+      "example": "true"
     }
   }
 }

--- a/test/uk/gov/hmrc/statepension/connectors/NispConnectorSpec.scala
+++ b/test/uk/gov/hmrc/statepension/connectors/NispConnectorSpec.scala
@@ -52,7 +52,8 @@ class NispConnectorSpec extends StatePensionUnitSpec with MockitoSugar with With
             |    "Dead"
             |  ],
             |  "pensionAge": 65,
-            |  "pensionDate": "2018-07-05"
+            |  "pensionDate": "2018-07-05",
+            |  "statePensionAgeUnderConsideration": false
             |}
           """.stripMargin
         ))
@@ -64,7 +65,8 @@ class NispConnectorSpec extends StatePensionUnitSpec with MockitoSugar with With
           Exclusion.Dead
         ),
         pensionAge = 65,
-        pensionDate = new LocalDate(2018, 7, 5)
+        pensionDate = new LocalDate(2018, 7, 5),
+        false
       ))
     }
 

--- a/test/uk/gov/hmrc/statepension/controllers/StatePensionControllerSpec.scala
+++ b/test/uk/gov/hmrc/statepension/controllers/StatePensionControllerSpec.scala
@@ -204,7 +204,7 @@ class StatePensionControllerSpec extends UnitSpec with WithFakeApplication {
 
     "return 403 with an error message for an MCI exclusion" in {
       val response = testStatePensionController(new StatePensionService {
-        override def getStatement(nino: Nino)(implicit hc: HeaderCarrier): Future[Either[StatePensionExclusion, StatePension]] = Left(StatePensionExclusion(List(Exclusion.ManualCorrespondenceIndicator), 0, new LocalDate(2050, 1, 1)))
+        override def getStatement(nino: Nino)(implicit hc: HeaderCarrier): Future[Either[StatePensionExclusion, StatePension]] = Left(StatePensionExclusion(List(Exclusion.ManualCorrespondenceIndicator), 0, new LocalDate(2050, 1, 1), false))
       }).get(nino)(emptyRequestWithHeader)
 
       status(response) shouldBe 403
@@ -213,7 +213,7 @@ class StatePensionControllerSpec extends UnitSpec with WithFakeApplication {
 
     "return 403 with an error message for a Dead exclusion" in {
       val response = testStatePensionController(new StatePensionService {
-        override def getStatement(nino: Nino)(implicit hc: HeaderCarrier): Future[Either[StatePensionExclusion, StatePension]] = Left(StatePensionExclusion(List(Exclusion.Dead), 0, new LocalDate(2050, 1, 1)))
+        override def getStatement(nino: Nino)(implicit hc: HeaderCarrier): Future[Either[StatePensionExclusion, StatePension]] = Left(StatePensionExclusion(List(Exclusion.Dead), 0, new LocalDate(2050, 1, 1), false))
       }).get(nino)(emptyRequestWithHeader)
 
       status(response) shouldBe 403
@@ -226,7 +226,8 @@ class StatePensionControllerSpec extends UnitSpec with WithFakeApplication {
           Left(StatePensionExclusion(
             List(Exclusion.Dead, Exclusion.ManualCorrespondenceIndicator),
             0,
-            new LocalDate(2050, 1, 1)
+            new LocalDate(2050, 1, 1),
+            false
           ))
       }).get(nino)(emptyRequestWithHeader)
 

--- a/test/uk/gov/hmrc/statepension/services/StatePensionServiceSpec.scala
+++ b/test/uk/gov/hmrc/statepension/services/StatePensionServiceSpec.scala
@@ -97,7 +97,8 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         result shouldBe Left(StatePensionExclusion(
           exclusionReasons = List(Exclusion.PostStatePensionAge),
           pensionAge = 66,
-          pensionDate = new LocalDate(2021, 5, 16)
+          pensionDate = new LocalDate(2021, 5, 16),
+          false
         ))
       }
     }
@@ -107,7 +108,8 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         result shouldBe Left(StatePensionExclusion(
           exclusionReasons = List(Exclusion.Dead),
           pensionAge = 66,
-          pensionDate = new LocalDate(2021, 5, 16)
+          pensionDate = new LocalDate(2021, 5, 16),
+          false
         ))
       }
     }
@@ -117,7 +119,8 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         result shouldBe Left(StatePensionExclusion(
           exclusionReasons = List(Exclusion.ManualCorrespondenceIndicator),
           pensionAge = 66,
-          pensionDate = new LocalDate(2021, 5, 16)
+          pensionDate = new LocalDate(2021, 5, 16),
+          false
         ))
       }
     }
@@ -546,6 +549,7 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
             statement.get.exclusionReasons shouldBe List(Exclusion.AmountDissonance)
             statement.get.pensionAge shouldBe 65
             statement.get.pensionDate.toString shouldBe "2019-09-06"
+            statement.get.statePensionAgeUnderConsideration.toString shouldBe "false"
           }
 
         }
@@ -1023,6 +1027,12 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         }
       }
 
+      "not have the statePensionAgeUnderConsideration flag enabled" in {
+        whenReady(exclusionF) { exclusion =>
+          exclusion.statePensionAgeUnderConsideration shouldBe false
+        }
+      }
+
       "log an exclusion metric" in {
         verify(service.metrics, times(1)).exclusion(
           Matchers.eq(Exclusion.Dead)
@@ -1092,6 +1102,12 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
       "have a pension date of 2016-1-1" in {
         whenReady(exclusionF) { exclusion =>
           exclusion.pensionDate shouldBe new LocalDate(2016, 1, 1)
+        }
+      }
+
+      "not have the statePensionAgeUnderConsideration flag enabled" in {
+        whenReady(exclusionF) { exclusion =>
+          exclusion.statePensionAgeUnderConsideration shouldBe false
         }
       }
 
@@ -1329,6 +1345,12 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         }
       }
 
+      "not have the statePensionAgeUnderConsideration flag enabled" in {
+        whenReady(exclusionF) { exclusion =>
+          exclusion.statePensionAgeUnderConsideration shouldBe false
+        }
+      }
+
       "log an exclusion metric" in {
         verify(service.metrics, times(1)).exclusion(
           Matchers.eq(Exclusion.AmountDissonance)
@@ -1393,6 +1415,12 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
         }
       }
 
+      "not have the statePensionAgeUnderConsideration flag enabled" in {
+        whenReady(exclusionF) { exclusion =>
+          exclusion.statePensionAgeUnderConsideration shouldBe false
+        }
+      }
+
       "log an exclusion metric" in {
         verify(service.metrics, times(1)).exclusion(
           Matchers.eq(Exclusion.IsleOfMan)
@@ -1454,6 +1482,12 @@ class StatePensionServiceSpec extends StatePensionUnitSpec with OneAppPerSuite w
       "have a pension date of 2018-1-1" in {
         whenReady(exclusionF) { exclusion =>
           exclusion.pensionDate shouldBe new LocalDate(2018, 1, 1)
+        }
+      }
+
+      "not have the statePensionAgeUnderConsideration flag enabled" in {
+        whenReady(exclusionF) { exclusion =>
+          exclusion.statePensionAgeUnderConsideration shouldBe false
         }
       }
 


### PR DESCRIPTION
Part of the story for change of state pension age, flag will be added to the exclusion response if their age falls within the target range AND the exclusion type is Isle of Man or Amount Dissonance.