### PR TITLE
Revert "DDCNLS-6519: Change auth predicate to always check for NINO"

### DIFF
--- a/app/uk/gov/hmrc/statepension/controllers/auth/AuthAction.scala
+++ b/app/uk/gov/hmrc/statepension/controllers/auth/AuthAction.scala
@@ -44,7 +44,7 @@ class AuthActionImpl @Inject()(val authConnector: AuthConnector)(implicit execut
       Future.successful(Some(BadRequest))
     } else {
       val uriNino: Option[String] = Some(matches.group(1))
-      authorised(ConfidenceLevel.L200 and Nino(true, uriNino)) {
+      authorised((ConfidenceLevel.L200 and Nino(true, uriNino)) or AuthProviders(PrivilegedApplication)) {
         Future.successful(None)
       }.recover {
         case t: Throwable =>

--- a/test/uk/gov/hmrc/statepension/controllers/auth/AuthActionSpec.scala
+++ b/test/uk/gov/hmrc/statepension/controllers/auth/AuthActionSpec.scala
@@ -71,7 +71,8 @@ class AuthActionSpec
         status(result) mustBe OK
 
         verify(mockAuthConnector)
-          .authorise[Unit](MockitoEq(ConfidenceLevel.L200 and Nino(true, Some(testNino))),
+          .authorise[Unit](MockitoEq(
+            (ConfidenceLevel.L200 and Nino(true, Some(testNino))) or AuthProviders(PrivilegedApplication)),
             any())(any(), any())
       }
 
@@ -84,6 +85,12 @@ class AuthActionSpec
       "return UNAUTHORIZED when the Nino is rejected by auth" in {
         val (result, _) =
           testAuthActionWith(Future.failed(InternalError("IncorrectNino")))
+        status(result) mustBe UNAUTHORIZED
+      }
+
+      "return UNAUTHORIZED when not a Privileged application" in {
+        val (result, _) =
+          testAuthActionWith(Future.failed(new UnsupportedAuthProvider))
         status(result) mustBe UNAUTHORIZED
       }
 


### PR DESCRIPTION
Reverts hmrc/state-pension#96