### PR TITLE
Revert "DDCNL-10166: Removed CL from API auth action and tests"

### DIFF
--- a/app/uk/gov/hmrc/statepension/controllers/auth/ApiAuthAction.scala
+++ b/app/uk/gov/hmrc/statepension/controllers/auth/ApiAuthAction.scala
@@ -16,11 +16,11 @@
 
 package uk.gov.hmrc.statepension.controllers.auth
 
-import com.google.inject.{ImplementedBy, Inject}
 import play.api.mvc.BodyParsers
 import uk.gov.hmrc.auth.core.AuthProvider.PrivilegedApplication
+import uk.gov.hmrc.auth.core.{AuthConnector, AuthProviders, ConfidenceLevel}
 import uk.gov.hmrc.auth.core.authorise.Predicate
-import uk.gov.hmrc.auth.core.{AuthConnector, AuthProviders}
+import com.google.inject.{ImplementedBy, Inject}
 
 import scala.concurrent.ExecutionContext
 import scala.util.matching.Regex
@@ -32,7 +32,7 @@ class ApiAuthActionImpl  @Inject()(
                               )
   extends AuthActionImpl(authConn, parse)(ec) with ApiAuthAction {
 
-  override val predicate: Predicate = AuthProviders(PrivilegedApplication)
+  override val predicate: Predicate = ConfidenceLevel.L200 or AuthProviders(PrivilegedApplication)
   override val matchNinoInUriPattern: Regex = "[ni|cope]/([^/]+)/?.*".r
 }
 

--- a/test/uk/gov/hmrc/statepension/controllers/auth/AuthActionSpec.scala
+++ b/test/uk/gov/hmrc/statepension/controllers/auth/AuthActionSpec.scala
@@ -74,7 +74,7 @@ class AuthActionSpec
 
           verify(mockAuthConnector)
             .authorise[Unit](MockitoEq(
-              AuthProviders(PrivilegedApplication)
+              ConfidenceLevel.L200 or AuthProviders(PrivilegedApplication)
             ), any())(any(), any())
         }
 
@@ -89,7 +89,7 @@ class AuthActionSpec
 
           verify(mockAuthConnector)
             .authorise[Unit](MockitoEq(
-              AuthProviders(PrivilegedApplication)
+              ConfidenceLevel.L200 or AuthProviders(PrivilegedApplication)
             ), any())(any(), any())
         }
 
@@ -101,12 +101,18 @@ class AuthActionSpec
 
           verify(mockAuthConnector)
             .authorise[Unit](MockitoEq(
-              AuthProviders(PrivilegedApplication)
+              ConfidenceLevel.L200 or AuthProviders(PrivilegedApplication)
             ), any())(any(), any())
         }
       }
 
       "return UNAUTHORIZED" when {
+        "the Confidence Level is less than 200" in {
+          val (result, _) =
+            testAuthActionWith(Future.failed(new InsufficientConfidenceLevel))
+          status(result) mustBe UNAUTHORIZED
+        }
+
         "the Nino is rejected by auth" in {
           val (result, _) =
             testAuthActionWith(Future.failed(InternalError("IncorrectNino")))


### PR DESCRIPTION
Reverts hmrc/state-pension#200